### PR TITLE
add types for graph JSON objects

### DIFF
--- a/src/lib/Graphs/GraphJSON.ts
+++ b/src/lib/Graphs/GraphJSON.ts
@@ -1,0 +1,15 @@
+export type LinkJSON = { node: number; socket: string };
+
+export type InputJSON = {
+  value?: string | number | boolean;
+  links?: LinkJSON[];
+}
+
+export type NodeJSON = {
+  type: string;
+  inputs?: {
+    [key: string]: InputJSON;
+  };
+};
+
+export type GraphJSON = NodeJSON[];

--- a/src/lib/Graphs/readGraphFromJSON.ts
+++ b/src/lib/Graphs/readGraphFromJSON.ts
@@ -9,6 +9,8 @@ import GraphTypeRegistry from './GraphTypeRegistry';
 export default function readGraphFromJSON(nodesJson: GraphJSON, graphTypeRegistry: GraphTypeRegistry): Graph {
   const graph = new Graph();
 
+  // console.log('input JSON', JSON.stringify(nodesJson, null, 2));
+
   if (nodesJson.length === 0) {
     console.warn('loadGraph: no nodes specified');
   }
@@ -51,14 +53,18 @@ export default function readGraphFromJSON(nodesJson: GraphJSON, graphTypeRegistr
 
   // connect up the graph edges from BehaviorNode inputs to outputs.  This is required to follow execution
   graph.nodes.forEach((node, nodeIndex) => {
+    // console.log(node);
     // initialize the inputs by resolving to the reference nodes.
     node.inputSockets.forEach((inputSocket) => {
+      // console.log(inputSocket);
       inputSocket.links.forEach((nodeSocketRef) => {
+        // console.log(nodeSocketRef);
         const upstreamOutputSocket = graph.nodes[nodeSocketRef.nodeIndex].getOutputSocket(nodeSocketRef.socketName);
         upstreamOutputSocket.links.push(new NodeSocketRef(nodeIndex, inputSocket.name));
       });
     });
   });
 
+  // console.log('output Graph', JSON.stringify(graph, null, 2));
   return graph;
 }

--- a/src/lib/Graphs/writeGraphToJSON.ts
+++ b/src/lib/Graphs/writeGraphToJSON.ts
@@ -1,21 +1,26 @@
 import Graph from './Graph';
+import {
+  GraphJSON, InputJSON, LinkJSON, NodeJSON,
+} from './GraphJSON';
 
-export default function writeGraphToJSON(graph: Graph): any {
-  const graphJson: any[] = [];
+export default function writeGraphToJSON(graph: Graph): GraphJSON {
+  const graphJson: GraphJSON = [];
+
   // create new BehaviorNode instances for each node in the json.
   graph.nodes.forEach((node) => {
-    const nodeJson: { [index:string]: any} = {
+    const nodeJson: NodeJSON = {
       type: node.typeName,
     };
 
-    const inputsJson: { [index:string]: any} = {};
+    const inputsJson: NodeJSON['inputs'] = {};
+
     node.inputSockets.forEach((inputSocket) => {
-      const inputJson: { [index:string]: any} = {};
+      const inputJson: InputJSON = {};
 
       if (inputSocket.links.length === 0) {
         inputJson.value = inputSocket.value;
       } else {
-        const linksJson: { [index:string]: any}[] = [];
+        const linksJson: LinkJSON[] = [];
         inputSocket.links.forEach((nodeSocketRef) => {
           linksJson.push({
             node: nodeSocketRef.nodeIndex,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,3 +21,6 @@ export { default as writeGraphToJSON } from './Graphs/writeGraphToJSON';
 // node registry
 export { default as GraphTypeRegistry } from './Graphs/GraphTypeRegistry';
 export { default as registerGenericNodes } from './Nodes/Generic/GenericNodes';
+
+// types
+export * from './Graphs/GraphJSON';


### PR DESCRIPTION
Fixes #27

- Adds types for JSON graph representations
- clean up some of the `any`s in the read/write functions.
- export the types in the build