### PR TITLE
fix input and output types for string and number constants

### DIFF
--- a/src/lib/Nodes/Generic/GenericNodes.ts
+++ b/src/lib/Nodes/Generic/GenericNodes.ts
@@ -41,8 +41,8 @@ export default function registerGenericNodes(registry: NodeTypeRegistry) {
   // logic: constants
 
   registry.register('logic/booleanConstant', () => new UnaryOp<boolean, boolean>('logic/booleanConstant', 'boolean', 'boolean', (a) => (a)));
-  registry.register('logic/numberConstant', () => new UnaryOp<number, number>('logic/numberConstant', 'boolean', 'boolean', (a) => (a)));
-  registry.register('logic/stringConstant', () => new UnaryOp<string, string>('logic/stringConstant', 'boolean', 'boolean', (a) => (a)));
+  registry.register('logic/numberConstant', () => new UnaryOp<number, number>('logic/numberConstant', 'number', 'number', (a) => (a)));
+  registry.register('logic/stringConstant', () => new UnaryOp<string, string>('logic/stringConstant', 'string', 'string', (a) => (a)));
 
   // logic: boolean logic
 


### PR DESCRIPTION
I couldnt work out why the maths example wasnt working in behave flow, thought it was my code for ages, but then tried using exec in this repo and got the same, turns out number constant was emitting a boolean `false` 