### PR TITLE
export nodespec types

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default [
         format: 'esm',
       },
     ],
-    plugins: [commonjs(), typescript({ rootDir: './src/lib' }), del({ targets: 'dist/lib/*' })],
+    plugins: [commonjs(), typescript({ rootDir: './src/lib' }), del({ targets: 'dist' })],
   },
   {
     input: 'dist/lib/index.d.ts',
@@ -35,7 +35,7 @@ export default [
         format: 'esm',
       },
     ],
-    plugins: [commonjs(), typescript({ rootDir: './src/examples/exec-graph' }), del({ targets: 'dist/examples/exec-graph/*' })],
+    plugins: [commonjs(), typescript({ rootDir: './src/examples/exec-graph' })],
   },
   {
     input: 'src/examples/web/index.ts',
@@ -45,7 +45,7 @@ export default [
         format: 'esm',
       },
     ],
-    plugins: [commonjs(), typescript({ rootDir: './src/examples/web' }), del({ targets: 'dist/examples/web/*' })],
+    plugins: [commonjs(), typescript({ rootDir: './src/examples/web' })],
   },
   {
     input: 'src/examples/export-node-spec/index.ts',
@@ -55,6 +55,6 @@ export default [
         format: 'esm',
       },
     ],
-    plugins: [commonjs(), typescript({ rootDir: './src/examples/export-node-spec' }), del({ targets: 'dist/examples/export-node-spec/*' })],
+    plugins: [commonjs(), typescript({ rootDir: './src/examples/export-node-spec' })],
   },
 ];

--- a/src/lib/Graphs/IO/NodeSpecJSON.ts
+++ b/src/lib/Graphs/IO/NodeSpecJSON.ts
@@ -1,17 +1,17 @@
-export type InputSocketSpec = {
+export type InputSocketSpecJSON = {
   name: string;
   valueType: 'flow' |'string'|'number'|'boolean',
   defaultValue?: string | number | boolean
 }
 
-export type OutputSocketSpec = {
+export type OutputSocketSpecJSON = {
   name: string;
   valueType: 'flow' |'string'|'number'|'boolean'
 }
 
-export type NodeSpec = {
+export type NodeSpecJSON = {
   type: string;
   category: string;
-  inputs: InputSocketSpec[];
-  outputs: OutputSocketSpec[];
+  inputs: InputSocketSpecJSON[];
+  outputs: OutputSocketSpecJSON[];
 };

--- a/src/lib/Graphs/IO/NodeSpecJSON.ts
+++ b/src/lib/Graphs/IO/NodeSpecJSON.ts
@@ -2,13 +2,13 @@ import { NodeCategory } from '../../Nodes/NodeCategory';
 
 export type InputSocketSpecJSON = {
   name: string;
-  valueType: 'flow' |'string'|'number'|'boolean',
-  defaultValue?: string | number | boolean
+  valueType: string,
+  defaultValue?: string
 }
 
 export type OutputSocketSpecJSON = {
   name: string;
-  valueType: 'flow' |'string'|'number'|'boolean'
+  valueType: string;
 }
 
 export type NodeSpecJSON = {

--- a/src/lib/Graphs/IO/NodeSpecJSON.ts
+++ b/src/lib/Graphs/IO/NodeSpecJSON.ts
@@ -1,20 +1,17 @@
-export type LinkJSON = { node: number; socket: string };
-
-export type InputSocketSpecJSON = {
-  name: string,
-  valueType: string,
-  defaultValue: string;
-}
-export type OutputSocketSpecJSON = {
-  name: string,
-  valueType: string,
+export type InputSocketSpec = {
+  name: string;
+  valueType: 'flow' |'string'|'number'|'boolean',
+  defaultValue: string | number | boolean | undefined
 }
 
-export type NodeSpecJSON = {
+export type OutputSocketSpec = {
+  name: string;
+  valueType: 'flow' |'string'|'number'|'boolean'
+}
+
+export type NodeSpec = {
   type: string;
   category: string;
-  inputs: InputSocketSpecJSON[];
-  outputs: OutputSocketSpecJSON[];
+  inputs: InputSocketSpec[];
+  outputs: OutputSocketSpec[];
 };
-
-export type NodeSpecsJSON = NodeSpecJSON[];

--- a/src/lib/Graphs/IO/NodeSpecJSON.ts
+++ b/src/lib/Graphs/IO/NodeSpecJSON.ts
@@ -1,7 +1,7 @@
 export type InputSocketSpec = {
   name: string;
   valueType: 'flow' |'string'|'number'|'boolean',
-  defaultValue: string | number | boolean | undefined
+  defaultValue?: string | number | boolean
 }
 
 export type OutputSocketSpec = {

--- a/src/lib/Graphs/IO/NodeSpecJSON.ts
+++ b/src/lib/Graphs/IO/NodeSpecJSON.ts
@@ -1,3 +1,5 @@
+import { NodeCategory } from '../../Nodes/NodeCategory';
+
 export type InputSocketSpecJSON = {
   name: string;
   valueType: 'flow' |'string'|'number'|'boolean',
@@ -11,7 +13,7 @@ export type OutputSocketSpecJSON = {
 
 export type NodeSpecJSON = {
   type: string;
-  category: string;
+  category: NodeCategory;
   inputs: InputSocketSpecJSON[];
   outputs: OutputSocketSpecJSON[];
 };

--- a/src/lib/Graphs/IO/writeNodeSpecsToJSON.ts
+++ b/src/lib/Graphs/IO/writeNodeSpecsToJSON.ts
@@ -1,24 +1,21 @@
-import { NodeCategory } from '../../Nodes/NodeCategory';
 import GraphRegistry from '../GraphRegistry';
-import {
-  InputSocketSpecJSON, NodeSpecJSON, NodeSpecsJSON, OutputSocketSpecJSON,
-} from './NodeSpecJSON';
+import { InputSocketSpec, NodeSpec, OutputSocketSpec } from './NodeSpecJSON';
 
-export default function writeNodeSpecsToJSON(registry: GraphRegistry): NodeSpecsJSON {
-  const nodeSpecsJSON: NodeSpecsJSON = [];
+export default function writeNodeSpecsToJSON(registry: GraphRegistry): NodeSpec[] {
+  const nodeSpecsJSON: NodeSpec[] = [];
 
   registry.nodes.nodeTypeNameToNodeFactory.forEach((nodeFactory, nodeType) => {
     const node = nodeFactory();
 
-    const nodeSpecJSON: NodeSpecJSON = {
+    const nodeSpecJSON: NodeSpec = {
       type: nodeType,
-      category: NodeCategory[node.category],
+      category: node.category,
       inputs: [],
       outputs: [],
     };
 
     node.inputSockets.forEach((inputSocket) => {
-      const socketSpecJSON: InputSocketSpecJSON = {
+      const socketSpecJSON: InputSocketSpec = {
         name: inputSocket.name,
         defaultValue: inputSocket.value,
         valueType: inputSocket.valueTypeName,
@@ -27,7 +24,7 @@ export default function writeNodeSpecsToJSON(registry: GraphRegistry): NodeSpecs
     });
 
     node.outputSockets.forEach((outputSocket) => {
-      const socketSpecJSON: OutputSocketSpecJSON = {
+      const socketSpecJSON: OutputSocketSpec = {
         name: outputSocket.name,
         valueType: outputSocket.valueTypeName,
       };

--- a/src/lib/Graphs/IO/writeNodeSpecsToJSON.ts
+++ b/src/lib/Graphs/IO/writeNodeSpecsToJSON.ts
@@ -1,13 +1,13 @@
 import GraphRegistry from '../GraphRegistry';
-import { InputSocketSpec, NodeSpec, OutputSocketSpec } from './NodeSpecJSON';
+import { InputSocketSpecJSON, NodeSpecJSON, OutputSocketSpecJSON } from './NodeSpecJSON';
 
-export default function writeNodeSpecsToJSON(registry: GraphRegistry): NodeSpec[] {
-  const nodeSpecsJSON: NodeSpec[] = [];
+export default function writeNodeSpecsToJSON(registry: GraphRegistry): NodeSpecJSON[] {
+  const nodeSpecsJSON: NodeSpecJSON[] = [];
 
   registry.nodes.nodeTypeNameToNodeFactory.forEach((nodeFactory, nodeType) => {
     const node = nodeFactory();
 
-    const nodeSpecJSON: NodeSpec = {
+    const nodeSpecJSON: NodeSpecJSON = {
       type: nodeType,
       category: node.category,
       inputs: [],
@@ -15,7 +15,7 @@ export default function writeNodeSpecsToJSON(registry: GraphRegistry): NodeSpec[
     };
 
     node.inputSockets.forEach((inputSocket) => {
-      const socketSpecJSON: InputSocketSpec = {
+      const socketSpecJSON: InputSocketSpecJSON = {
         name: inputSocket.name,
         defaultValue: inputSocket.value,
         valueType: inputSocket.valueTypeName,
@@ -24,7 +24,7 @@ export default function writeNodeSpecsToJSON(registry: GraphRegistry): NodeSpec[
     });
 
     node.outputSockets.forEach((outputSocket) => {
-      const socketSpecJSON: OutputSocketSpec = {
+      const socketSpecJSON: OutputSocketSpecJSON = {
         name: outputSocket.name,
         valueType: outputSocket.valueTypeName,
       };

--- a/src/lib/Nodes/Generic/Actions/Log.ts
+++ b/src/lib/Nodes/Generic/Actions/Log.ts
@@ -1,13 +1,12 @@
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import StringSocket from '../../../Sockets/Typed/StringSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class Log extends Node {
   constructor() {
     super(
-      NodeCategory.Action,
+      'Action',
       'action/log',
       [new FlowSocket(), new StringSocket('text')],
       [new FlowSocket()],

--- a/src/lib/Nodes/Generic/Events/Start.ts
+++ b/src/lib/Nodes/Generic/Events/Start.ts
@@ -1,6 +1,5 @@
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 
 // TODO: Figure out how to force the evaluation of these from the outside.
 // TODO: Figure out how to set values for the outputs in a consistent way.  Add to context?  Have a set of output values pre-specified when you trigger it?
@@ -9,7 +8,7 @@ import { NodeCategory } from '../../NodeCategory';
 export default class Start extends Node {
   constructor() {
     super(
-      NodeCategory.Event,
+      'Event',
       'event/start',
       [],
       [new FlowSocket()],

--- a/src/lib/Nodes/Generic/Events/Tick.ts
+++ b/src/lib/Nodes/Generic/Events/Tick.ts
@@ -1,11 +1,10 @@
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 
 export default class Tick extends Node {
   constructor() {
     super(
-      NodeCategory.Event,
+      'Event',
       'event/tick',
       [],
       [new FlowSocket()],

--- a/src/lib/Nodes/Generic/Flow/Branch.ts
+++ b/src/lib/Nodes/Generic/Flow/Branch.ts
@@ -1,13 +1,12 @@
 import BooleanSocket from '../../../Sockets/Typed/BooleanSocket';
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class Branch extends Node {
   constructor() {
     super(
-      NodeCategory.Flow,
+      'Flow',
       'flow/branch',
       [
         new FlowSocket(),

--- a/src/lib/Nodes/Generic/Flow/FlipFlop.ts
+++ b/src/lib/Nodes/Generic/Flow/FlipFlop.ts
@@ -1,7 +1,6 @@
 import BooleanSocket from '../../../Sockets/Typed/BooleanSocket';
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class FlipFlop extends Node {
@@ -9,7 +8,7 @@ export default class FlipFlop extends Node {
 
   constructor() {
     super(
-      NodeCategory.Flow,
+      'Flow',
       'flow/flipFlop',
       [
         new FlowSocket(),

--- a/src/lib/Nodes/Generic/Flow/ForLoop.ts
+++ b/src/lib/Nodes/Generic/Flow/ForLoop.ts
@@ -1,13 +1,12 @@
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import NumberSocket from '../../../Sockets/Typed/NumberSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class ForLoop extends Node {
   constructor() {
     super(
-      NodeCategory.Flow,
+      'Flow',
       'flow/forLoop',
       [
         new FlowSocket(),

--- a/src/lib/Nodes/Generic/Flow/Sequence.ts
+++ b/src/lib/Nodes/Generic/Flow/Sequence.ts
@@ -1,6 +1,5 @@
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 // https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/Blueprints/UserGuide/flow/
@@ -8,7 +7,7 @@ import NodeEvalContext from '../../NodeEvalContext';
 export default class Sequence extends Node {
   constructor() {
     super(
-      NodeCategory.Flow,
+      'Flow',
       'flow/sequence',
       [new FlowSocket()],
       [

--- a/src/lib/Nodes/Generic/Logic/BinaryOp.ts
+++ b/src/lib/Nodes/Generic/Logic/BinaryOp.ts
@@ -1,12 +1,11 @@
 import createTypedSocket from '../../../Sockets/Typed/TypedSocketFactory';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class BinaryOp<Input, Output> extends Node {
   constructor(nodeName: string, inputValueType: string, outputValueType: string, public binaryEvalFunc: (a: Input, b: Input) => Output) {
     super(
-      NodeCategory.Logic,
+      'Logic',
       nodeName,
       [
         createTypedSocket(inputValueType, 'a'),

--- a/src/lib/Nodes/Generic/Logic/NullaryOp.ts
+++ b/src/lib/Nodes/Generic/Logic/NullaryOp.ts
@@ -1,12 +1,11 @@
 import createTypedSocket from '../../../Sockets/Typed/TypedSocketFactory';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class NullaryOp<Output> extends Node {
   constructor(nodeName: string, outputValueType: string, public nullaryEvalFunc: () => Output) {
     super(
-      NodeCategory.Logic,
+      'Logic',
       nodeName,
       [],
       [createTypedSocket(outputValueType, 'result')],

--- a/src/lib/Nodes/Generic/Logic/UnaryOp.ts
+++ b/src/lib/Nodes/Generic/Logic/UnaryOp.ts
@@ -1,12 +1,11 @@
 import createTypedSocket from '../../../Sockets/Typed/TypedSocketFactory';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class UnaryOp<Input, Output> extends Node {
   constructor(nodeName: string, inputValueType: string, outputValueType: string, public unaryEvalFunc: (a: Input) => Output) {
     super(
-      NodeCategory.Logic,
+      'Logic',
       nodeName,
       [
         createTypedSocket(inputValueType, 'a'),

--- a/src/lib/Nodes/Generic/State/StateExists.ts
+++ b/src/lib/Nodes/Generic/State/StateExists.ts
@@ -1,13 +1,12 @@
 import BooleanSocket from '../../../Sockets/Typed/BooleanSocket';
 import StringSocket from '../../../Sockets/Typed/StringSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class StateExists extends Node {
   constructor() {
     super(
-      NodeCategory.Logic,
+      'Logic',
       'state/exists',
       [new StringSocket('identifier')],
       [new BooleanSocket('result')],

--- a/src/lib/Nodes/Generic/State/StateGet.ts
+++ b/src/lib/Nodes/Generic/State/StateGet.ts
@@ -1,13 +1,12 @@
 import Socket from '../../../Sockets/Socket';
 import StringSocket from '../../../Sockets/Typed/StringSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class StateGet extends Node {
   constructor(name:string, socketFactory: (socketName:string) => Socket) {
     super(
-      NodeCategory.Logic,
+      'Logic',
       name,
       [new StringSocket('identifier'), socketFactory('defaultValue')],
       [socketFactory('result')],

--- a/src/lib/Nodes/Generic/State/StateSet.ts
+++ b/src/lib/Nodes/Generic/State/StateSet.ts
@@ -2,13 +2,12 @@ import Socket from '../../../Sockets/Socket';
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import StringSocket from '../../../Sockets/Typed/StringSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 export default class StateSet extends Node {
   constructor(name:string, socketFactory: (socketName:string) => Socket) {
     super(
-      NodeCategory.Logic,
+      'Logic',
       name,
       [new FlowSocket(), new StringSocket('identifier'), socketFactory('value')],
       [new FlowSocket()],

--- a/src/lib/Nodes/Generic/Time/Delay.ts
+++ b/src/lib/Nodes/Generic/Time/Delay.ts
@@ -1,7 +1,6 @@
 import FlowSocket from '../../../Sockets/Typed/FlowSocket';
 import NumberSocket from '../../../Sockets/Typed/NumberSocket';
 import Node from '../../Node';
-import { NodeCategory } from '../../NodeCategory';
 import NodeEvalContext from '../../NodeEvalContext';
 
 // ASYNC - asynchronous evaluation
@@ -10,7 +9,7 @@ import NodeEvalContext from '../../NodeEvalContext';
 export default class Delay extends Node {
   constructor() {
     super(
-      NodeCategory.Time,
+      'Time',
       'time/delay',
       [
         new FlowSocket(),

--- a/src/lib/Nodes/NodeCategory.ts
+++ b/src/lib/Nodes/NodeCategory.ts
@@ -1,10 +1,9 @@
-export enum NodeCategory {
-    Action,
-    Query,
-    Logic,
-    Event,
-    State,
-    Flow,
-    Time,
-    None
-}
+export type NodeCategory =
+  | 'Action'
+  | 'Query'
+  | 'Logic'
+  | 'Event'
+  | 'State'
+  | 'Flow'
+  | 'Time'
+  | 'None';

--- a/src/lib/Sockets/Socket.ts
+++ b/src/lib/Sockets/Socket.ts
@@ -5,7 +5,7 @@ export default class Socket {
 
   constructor(
       public name: string,
-      public valueTypeName: 'flow' | 'string' | 'number' | 'boolean',
+      public valueTypeName: string,
       public value: any | undefined,
   ) {
   }

--- a/src/lib/Sockets/Socket.ts
+++ b/src/lib/Sockets/Socket.ts
@@ -5,7 +5,7 @@ export default class Socket {
 
   constructor(
       public name: string,
-      public valueTypeName: string,
+      public valueTypeName: 'flow' | 'string' | 'number' | 'boolean',
       public value: any | undefined,
   ) {
   }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -31,3 +31,4 @@ export { default as validateLinks } from './Graphs/Validation/validateLinks';
 
 // types
 export * from './Graphs/IO/GraphJSON';
+export * from './Graphs/IO/NodeSpecJSON';


### PR DESCRIPTION
This adds the nodespec types to the build export, and tightens up a few points in the type to more accurately reflect usage.

I've also changed the enum for NodeCategory to a string union, as this slightly simplifies the code (requires less imports and no conversion from numeric index back to string). This is slightly personal preference, so happy to remove this change if you disagree.