### PR TITLE
Proposal for ValueType

### DIFF
--- a/src/lib/Graphs/IO/readGraphFromJSON.ts
+++ b/src/lib/Graphs/IO/readGraphFromJSON.ts
@@ -44,7 +44,7 @@ export default function readGraphFromJSON(graphJson: GraphJSON, registry: GraphR
         const inputJson = inputsJson[socket.name];
         if (inputJson.value !== undefined) {
         // eslint-disable-next-line no-param-reassign
-          socket.value = registry.values.get(socket.valueTypeName).parse(inputJson.value);
+          socket.value = registry.values.get(socket.valueTypeName).deserialize(inputJson.value);
         }
 
         if (inputJson.links !== undefined) {

--- a/src/lib/Graphs/IO/writeGraphToJSON.ts
+++ b/src/lib/Graphs/IO/writeGraphToJSON.ts
@@ -34,7 +34,7 @@ export default function writeGraphToJSON(graph: Graph, registry: GraphRegistry):
         const inputJson: InputJSON = {};
 
         if (inputSocket.links.length === 0) {
-          inputJson.value = registry.values.get(inputSocket.valueTypeName).toString(inputSocket.value);
+          inputJson.value = registry.values.get(inputSocket.valueTypeName).serialize(inputSocket.value);
         } else {
           const linksJson: LinkJSON[] = [];
           inputSocket.links.forEach((nodeSocketRef) => {

--- a/src/lib/Values/ValueType.ts
+++ b/src/lib/Values/ValueType.ts
@@ -1,9 +1,9 @@
-export default class ValueType {
+export default class ValueType<TValue = any, TJson = any> {
   constructor(
     public name: string,
-    public creator: () => any,
-    public parse: (text: string)=>any,
-    public toString: (value: any)=> string,
+    public creator: () => TValue,
+    public deserialize: (text: TJson) => TValue,
+    public serialize: (value: TValue) => TJson,
   ) {
   }
 }

--- a/src/lib/Values/ValueTypeRegistry.ts
+++ b/src/lib/Values/ValueTypeRegistry.ts
@@ -5,10 +5,22 @@ export default class ValueTypeRegistry {
 
   constructor() {
     // register core types
-    this.register(new ValueType('flow', () => '', () => '', () => ''));
-    this.register(new ValueType('string', () => '', (text) => text, (value) => (value as string)));
+    this.register(new ValueType('string', () => '', (text: string) => text, (value) => (value as string)));
     this.register(new ValueType('boolean', () => false, (text) => (text === 'true'), (value) => ((value as boolean) ? 'true' : 'false')));
-    this.register(new ValueType('number', () => 0, (text) => parseFloat(text), (value) => `${(value as number)}`));
+    this.register(
+      new ValueType(
+        'number',
+        () => 0,
+        (text: string | number) => {
+          if (typeof text === 'string') {
+            return parseFloat(text);
+          }
+
+          return text;
+        },
+        (value) => value,
+      ),
+    );
   }
 
   register(valueType: ValueType) {


### PR DESCRIPTION
I want to discuss the following things:

1. Not only string could be parsed. For example, there are already `number` values in examples/basics/Math.json. In my project, I defined `type Vector3 = {x: number, y: number, z: number}` and it's serialized to `value: {x: 1, y: 2, z: 3}`. So serialized value can be any type
2. Let's rename `parse/toString` to `serialize/deserialize` because if we apply point 1 we won't work with strings anymore. We will just deserialize `TypeA` to `TypeB` and serialize `TypeB` to `TypeA`.
3. I also added generics to ValueType<TypeB = any, TypeA = any>. It'll allow us to type our incomes and outcomes