### PR TITLE
add back node categories.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "behave-graph",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Simple, extensible behavior graph engine",
   "type": "module",
   "main": "src/lib/index.ts",

--- a/src/lib/Graphs/IO/NodeSpecJSON.ts
+++ b/src/lib/Graphs/IO/NodeSpecJSON.ts
@@ -1,3 +1,5 @@
+import { NodeCategory } from '../../Nodes/NodeCategory';
+
 export type InputSocketSpecJSON = {
   name: string;
   valueType: string,
@@ -11,7 +13,7 @@ export type OutputSocketSpecJSON = {
 
 export type NodeSpecJSON = {
   type: string;
-  category: string;
+  category: NodeCategory;
   inputs: InputSocketSpecJSON[];
   outputs: OutputSocketSpecJSON[];
 };

--- a/src/lib/Nodes/Node.ts
+++ b/src/lib/Nodes/Node.ts
@@ -1,5 +1,6 @@
 import { Metadata } from '../Graphs/Metadata';
 import Socket from '../Sockets/Socket';
+import { NodeCategory } from './NodeCategory';
 import { NodeEvalFunction } from './NodeEvalFunction';
 
 function findSocketByName(sockets: Socket[], name: string): Socket | undefined {
@@ -16,7 +17,7 @@ export default class Node {
   public interruptibleAsync = false;
 
   constructor(
-      public readonly category: string,
+      public readonly category: NodeCategory,
       public readonly typeName: string,
       public readonly inputSockets: Socket[],
       public readonly outputSockets: Socket[],

--- a/src/lib/Nodes/NodeCategory.ts
+++ b/src/lib/Nodes/NodeCategory.ts
@@ -1,0 +1,9 @@
+export type NodeCategory =
+  | 'Action'
+  | 'Query'
+  | 'Logic'
+  | 'Event'
+  | 'Variable'
+  | 'Flow'
+  | 'Time'
+  | 'None';

--- a/src/lib/Profiles/Core/Events/OnVariableChanged.ts
+++ b/src/lib/Profiles/Core/Events/OnVariableChanged.ts
@@ -5,7 +5,7 @@ import Socket from '../../../Sockets/Socket';
 export default class OnVariableChanged extends Node {
   constructor(name:string, public valueTypeName: string) {
     super(
-      'Variables',
+      'Event',
       name,
       [
         new Socket('id', 'variable'),


### PR DESCRIPTION
I was wrong to remove @beeglebug's NodeCategory's enum: https://github.com/bhouston/behave-graph/blob/cf62f18eab6e5959b5e7afc2a49ce6dfbfc1743e/src/lib/Graphs/IO/NodeSpecJSON.ts

This commit adds it back!