### PR TITLE
add performance test and output performance numbers on each run.

### DIFF
--- a/examples/core/flow/PerformanceTest.json
+++ b/examples/core/flow/PerformanceTest.json
@@ -1,0 +1,137 @@
+{
+    "nodes": [
+        {
+            "type": "lifecycle/start",
+            "id": "0"
+        },
+        {
+            "type": "action/log",
+            "id": "1",
+            "inputs": {
+                "flow": {
+                    "links": [
+                        {
+                            "nodeId": "0",
+                            "socket": "flow"
+                        }
+                    ]
+                },
+                "text": {
+                    "value": "Starting 1,000,000 iteration for-loop..."
+                }
+            }
+        },
+        {
+            "type": "flow/forLoop",
+            "id": "2",
+            "inputs": {
+                "startIndex": {
+                    "value": 0
+                },
+                "endIndex": {
+                    "value": 10000000
+                },
+                "flow": {
+                    "links": [
+                        {
+                            "nodeId": "1",
+                            "socket": "flow"
+                        }
+                    ]
+                }
+            }
+        },
+
+        {
+            "type": "logic/numberModulus",
+            "id": "3",
+            "inputs": {
+                "a": {
+                    "links": [
+                        {
+                            "nodeId": "2",
+                            "socket": "index"
+                        }
+                    ]
+                },
+                "b": {
+                    "value": 1000000
+                }
+            }
+        },
+
+        {
+            "type": "logic/numberEqual",
+            "id": "4",
+            "inputs": {
+                "a": {
+                    "links": [
+                        {
+                            "nodeId": "3",
+                            "socket": "result"
+                        }
+                    ]
+                },
+                "b": {
+                    "value": 0
+                }
+            }
+        },
+        {
+            "type": "flow/branch",
+            "id": "5",
+            "inputs": {
+                "flow": {
+                    "links": [
+                        {
+                            "nodeId": "2",
+                            "socket": "loopBody"
+                        }
+                    ]
+                },
+                "condition": {
+                    "links": [
+                        {
+                            "nodeId": "4",
+                            "socket": "result"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "action/log",
+            "id": "6",
+            "inputs": {
+                "flow": {
+                    "links": [
+                        {
+                            "nodeId": "5",
+                            "socket": "true"
+                        }
+                    ]
+                },
+                "text": {
+                    "value": "100,000 more iterations!"
+                }
+            }
+        },
+        {
+            "type": "action/log",
+            "id": "7",
+            "inputs": {
+                "flow": {
+                    "links": [
+                        {
+                            "nodeId": "2",
+                            "socket": "completed"
+                        }
+                    ]
+                },
+                "text": {
+                    "value": "Completed For Loop!"
+                }
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "behave-graph",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Simple, extensible behavior graph engine",
   "type": "module",
   "main": "src/lib/index.ts",

--- a/src/examples/exec-graph/index.ts
+++ b/src/examples/exec-graph/index.ts
@@ -60,14 +60,16 @@ async function main() {
     }
   });
 
+  const startTime = Date.now();
+
   Logger.verbose('initialize graph');
-  await graphEvaluator.executeAll();
+  let numSteps = await graphEvaluator.executeAll();
 
   Logger.verbose('triggering start event');
   manualLifecycleEventEmitter.startEvent.emit();
 
   Logger.verbose('executing all (async)');
-  await graphEvaluator.executeAllAsync(5.0);
+  numSteps += await graphEvaluator.executeAllAsync(5.0);
 
   for (let tick = 0; tick < 5; tick++) {
     Logger.verbose('triggering tick');
@@ -75,14 +77,18 @@ async function main() {
 
     Logger.verbose('executing all (async)');
     // eslint-disable-next-line no-await-in-loop
-    await graphEvaluator.executeAllAsync(5.0);
+    numSteps += await graphEvaluator.executeAllAsync(5.0);
   }
 
   Logger.verbose('triggering end event');
   manualLifecycleEventEmitter.endEvent.emit();
 
   Logger.verbose('executing all (async)');
-  await graphEvaluator.executeAllAsync(5.0);
+  numSteps += await graphEvaluator.executeAllAsync(5.0);
+
+  const deltaTime = Date.now() - startTime;
+
+  Logger.info(`  ${numSteps} nodes executed in ${deltaTime / 1000} seconds, at a rate of ${(numSteps * 1000) / deltaTime} steps/second`);
 }
 
 main();

--- a/src/lib/Events/EventEmitter.ts
+++ b/src/lib/Events/EventEmitter.ts
@@ -18,4 +18,8 @@ export default class EventEmitter<T> {
   emit(event: T) {
     this.listeners.forEach((listener) => { listener(event); });
   }
+
+  get listenerCount(): number {
+    return this.listeners.length;
+  }
 }

--- a/src/lib/Profiles/Core/Flow/Branch.ts
+++ b/src/lib/Profiles/Core/Flow/Branch.ts
@@ -9,7 +9,7 @@ export default class Branch extends Node {
       'flow/branch',
       [
         new Socket('flow', 'flow'),
-        new Socket('string', 'condition'),
+        new Socket('boolean', 'condition'),
       ],
       [
         new Socket('flow', 'true'),

--- a/src/lib/Profiles/Core/Flow/FlipFlop.ts
+++ b/src/lib/Profiles/Core/Flow/FlipFlop.ts
@@ -15,7 +15,7 @@ export default class FlipFlop extends Node {
       [
         new Socket('flow', 'on'),
         new Socket('flow', 'off'),
-        new Socket('string', 'isOn'),
+        new Socket('boolean', 'isOn'),
       ],
       (context: NodeEvalContext) => {
         context.writeOutput('isOn', this.isOn);

--- a/src/lib/Profiles/Core/registerCoreProfile.ts
+++ b/src/lib/Profiles/Core/registerCoreProfile.ts
@@ -64,6 +64,7 @@ export default function registerCoreProfile(registry: Registry) {
   nodes.register('logic/numberPow', () => new In2Out1FuncNode<number, number, number>('logic/numberPow', 'number', 'number', 'number', (a, b) => (a ** b)));
   nodes.register('logic/numberNegate', () => new In1Out1FuncNode<number, number>('logic/numberNegate', 'number', 'number', (a) => (-a)));
   nodes.register('logic/numberSqrt', () => new In1Out1FuncNode<number, number>('logic/numberSqrt', 'number', 'number', (a) => (Math.sqrt(a))));
+  nodes.register('logic/numberModulus', () => new In2Out1FuncNode<number, number, number>('logic/numberModulus', 'number', 'number', 'number', (a, b) => (a % b)));
 
   // logic: exponential
 


### PR DESCRIPTION
This performance test is showing these numbers on my MacMini M1:

```
[9/26/2022, 12:55:10 PM] INFO:  Starting 1,000,000 iteration for-loop...
[9/26/2022, 12:55:10 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:11 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:12 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:13 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:14 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:15 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:15 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:16 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:17 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:18 PM] INFO:  100,000 more iterations!
[9/26/2022, 12:55:19 PM] INFO:  Completed For Loop!
[9/26/2022, 12:55:19 PM] INFO:    20000016 nodes executed in 9.063 seconds, at a rate of 2206776.5640516384 steps/second
```