### PR TITLE
cleanup removal of Abstraction registry

### DIFF
--- a/docs/Abstractions.md
+++ b/docs/Abstractions.md
@@ -46,11 +46,3 @@ export class DefaultLogger implements ILogger {
   }
 }
 ```
-
-How to register drivers for specific abstractions?  You use the main registry and you register your driver along with specifying the abstraction it supports.  Only a single driver per abstraction interface is supported.
-
-Here is the registration of the DefaultLogger implementation:
-
-```typescript
-registry.abstractions.register('ILogger', new DefaultLogger());
-```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "behave-graph",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Simple, extensible behavior graph engine",
   "type": "module",
   "main": "dist/lib",

--- a/src/examples/exec-graph/index.ts
+++ b/src/examples/exec-graph/index.ts
@@ -9,13 +9,13 @@ import { traceToLogger } from '../../lib/Execution/traceToLogger.js';
 import { readGraphFromJSON } from '../../lib/Graphs/IO/readGraphFromJSON.js';
 import { writeGraphToJSON } from '../../lib/Graphs/IO/writeGraphToJSON.js';
 import { validateGraph } from '../../lib/Graphs/Validation/validateGraph.js';
+import { DefaultLogger, ManualLifecycleEventEmitter } from '../../lib/index.js';
 import { parseSafeFloat } from '../../lib/parseFloats.js';
 import { registerCoreProfile } from '../../lib/Profiles/Core/registerCoreProfile.js';
 import { registerSceneProfile } from '../../lib/Profiles/Scene/registerSceneProfile.js';
 import { Registry } from '../../lib/Registry.js';
 import { validateRegistry } from '../../lib/validateRegistry.js';
 import { DummyScene } from './DummyScene.js';
-import { DefaultLogger, ManualLifecycleEventEmitter } from '../../lib/index.js';
 
 async function main() {
   //Logger.onVerbose.clear();
@@ -98,9 +98,9 @@ async function main() {
       }
 
       if (manualLifecycleEventEmitter.tickEvent.listenerCount > 0) {
-        const iteations = parseSafeFloat(programOptions.iterations, 5);
-        for (let tick = 0; tick < iteations; tick++) {
-          Logger.verbose(`triggering tick (${tick} of ${iteations})`);
+        const iterations = parseSafeFloat(programOptions.iterations, 5);
+        for (let tick = 0; tick < iterations; tick++) {
+          Logger.verbose(`triggering tick (${tick} of ${iterations})`);
           manualLifecycleEventEmitter.tickEvent.emit();
 
           Logger.verbose('executing all (async)');

--- a/src/examples/three/index.ts
+++ b/src/examples/three/index.ts
@@ -53,7 +53,7 @@ async function loadThreeScene() {
 
   const threeScene = new ThreeScene(gltf.scene, glTFJson);
 
-  return {threeScene, gltf};
+  return { threeScene, gltf };
 }
 
 async function main() {
@@ -61,7 +61,7 @@ async function main() {
   const manualLifecycleEventEmitter = new ManualLifecycleEventEmitter();
   const logger = new DefaultLogger();
 
-  const {threeScene, gltf} = await loadThreeScene();
+  const { threeScene, gltf } = await loadThreeScene();
 
   registerCoreProfile(registry, logger, manualLifecycleEventEmitter);
   registerSceneProfile(registry, threeScene);
@@ -76,7 +76,6 @@ async function main() {
   const graphJson = await graphFetchResponse.json();
   const graph = readGraphFromJSON(graphJson, registry);
   graph.name = graphJsonPath;
-
 
   // await fs.writeFile('./examples/test.json', JSON.stringify(writeGraphToJSON(graph), null, ' '), { encoding: 'utf-8' });
   const errorList: string[] = [];
@@ -126,7 +125,7 @@ async function main() {
   localScene.environment = texture;
 
   localScene.add(gltf.scene);
-  
+
   threeScene.onSceneChanged.addListener(() => {
     render();
   });

--- a/src/lib/Profiles/Core/Debug/DebugLog.ts
+++ b/src/lib/Profiles/Core/Debug/DebugLog.ts
@@ -6,14 +6,19 @@ import { Socket } from '../../../Sockets/Socket.js';
 import { ILogger } from '../Abstractions/ILogger.js';
 
 export class Log extends FlowNode {
-  public static Description = (logger: ILogger) => new NodeDescription(
-    'debug/log',
-    'Action',
-    'Debug Log',
-    (description, graph) => new Log(description, graph, logger)
-  );
+  public static Description = (logger: ILogger) =>
+    new NodeDescription(
+      'debug/log',
+      'Action',
+      'Debug Log',
+      (description, graph) => new Log(description, graph, logger)
+    );
 
-  constructor(description: NodeDescription, graph: Graph, private readonly logger: ILogger) {
+  constructor(
+    description: NodeDescription,
+    graph: Graph,
+    private readonly logger: ILogger
+  ) {
     super(
       description,
       graph,

--- a/src/lib/Profiles/Core/Lifecycle/LifecycleOnEnd.ts
+++ b/src/lib/Profiles/Core/Lifecycle/LifecycleOnEnd.ts
@@ -8,14 +8,20 @@ import { ILifecycleEventEmitter } from '../Abstractions/ILifecycleEventEmitter.j
 
 // inspired by: https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/Blueprints/UserGuide/Events/
 export class LifecycleOnEnd extends EventNode {
-  public static Description = (emitter: ILifecycleEventEmitter) => new NodeDescription(
-    'lifecycle/onEnd',
-    'Event',
-    'On End',
-    (description, graph) => new LifecycleOnEnd(description, graph, emitter)
-  );
+  public static Description = (lifecycleEventEmitter: ILifecycleEventEmitter) =>
+    new NodeDescription(
+      'lifecycle/onEnd',
+      'Event',
+      'On End',
+      (description, graph) =>
+        new LifecycleOnEnd(description, graph, lifecycleEventEmitter)
+    );
 
-  constructor(description: NodeDescription, graph: Graph, private readonly lifecycleEvents: ILifecycleEventEmitter) {
+  constructor(
+    description: NodeDescription,
+    graph: Graph,
+    private readonly lifecycleEventEmitter: ILifecycleEventEmitter
+  ) {
     super(description, graph, [], [new Socket('flow', 'flow')]);
   }
 
@@ -27,15 +33,13 @@ export class LifecycleOnEnd extends EventNode {
       engine.commitToNewFiber(this, 'flow');
     };
 
-    const lifecycleEvents = this.lifecycleEvents;
-    lifecycleEvents.endEvent.removeListener(this.onEndEvent);
+    this.lifecycleEventEmitter.endEvent.removeListener(this.onEndEvent);
   }
 
   dispose(engine: Engine) {
     Assert.mustBeTrue(this.onEndEvent !== undefined);
     if (this.onEndEvent !== undefined) {
-      const lifecycleEvents = this.lifecycleEvents;
-      lifecycleEvents.endEvent.removeListener(this.onEndEvent);
+      this.lifecycleEventEmitter.endEvent.removeListener(this.onEndEvent);
     }
   }
 }

--- a/src/lib/Profiles/Core/Lifecycle/LifecycleOnStart.ts
+++ b/src/lib/Profiles/Core/Lifecycle/LifecycleOnStart.ts
@@ -8,14 +8,20 @@ import { ILifecycleEventEmitter } from '../Abstractions/ILifecycleEventEmitter.j
 
 // inspired by: https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/Blueprints/UserGuide/Events/
 export class LifecycleOnStart extends EventNode {
-  public static Description = (emitter: ILifecycleEventEmitter) => new NodeDescription(
-    'lifecycle/onStart',
-    'Event',
-    'On Start',
-    (description, graph) => new LifecycleOnStart(description, graph, emitter)
-  );
+  public static Description = (lifecycleEventEmitter: ILifecycleEventEmitter) =>
+    new NodeDescription(
+      'lifecycle/onStart',
+      'Event',
+      'On Start',
+      (description, graph) =>
+        new LifecycleOnStart(description, graph, lifecycleEventEmitter)
+    );
 
-  constructor(description: NodeDescription, graph: Graph, private readonly lifecycleEvents: ILifecycleEventEmitter) {
+  constructor(
+    description: NodeDescription,
+    graph: Graph,
+    private readonly lifecycleEventEmitter: ILifecycleEventEmitter
+  ) {
     super(description, graph, [], [new Socket('flow', 'flow')]);
   }
 
@@ -27,15 +33,13 @@ export class LifecycleOnStart extends EventNode {
       engine.commitToNewFiber(this, 'flow');
     };
 
-    const lifecycleEvents = this.lifecycleEvents;
-    lifecycleEvents.startEvent.addListener(this.onStartEvent);
+    this.lifecycleEventEmitter.startEvent.addListener(this.onStartEvent);
   }
 
   dispose(engine: Engine) {
     Assert.mustBeTrue(this.onStartEvent !== undefined);
     if (this.onStartEvent !== undefined) {
-      const lifecycleEvents = this.lifecycleEvents;
-      lifecycleEvents.startEvent.removeListener(this.onStartEvent);
+      this.lifecycleEventEmitter.startEvent.removeListener(this.onStartEvent);
     }
   }
 }

--- a/src/lib/Profiles/Core/Lifecycle/LifecycleOnTick.ts
+++ b/src/lib/Profiles/Core/Lifecycle/LifecycleOnTick.ts
@@ -8,14 +8,20 @@ import { ILifecycleEventEmitter } from '../Abstractions/ILifecycleEventEmitter.j
 
 // inspired by: https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/Blueprints/UserGuide/Events/
 export class LifecycleOnTick extends EventNode {
-  public static Description = (emitter: ILifecycleEventEmitter) => new NodeDescription(
-    'lifecycle/onTick',
-    'Event',
-    'On Tick',
-    (description, graph) => new LifecycleOnTick(description, graph, emitter)
-  );
+  public static Description = (lifecycleEventEmitter: ILifecycleEventEmitter) =>
+    new NodeDescription(
+      'lifecycle/onTick',
+      'Event',
+      'On Tick',
+      (description, graph) =>
+        new LifecycleOnTick(description, graph, lifecycleEventEmitter)
+    );
 
-  constructor(description: NodeDescription, graph: Graph, private readonly lifecycleEvents: ILifecycleEventEmitter) {
+  constructor(
+    description: NodeDescription,
+    graph: Graph,
+    private readonly lifecycleEventEmitter: ILifecycleEventEmitter
+  ) {
     super(
       description,
       graph,
@@ -42,15 +48,13 @@ export class LifecycleOnTick extends EventNode {
       lastTickTime = currentTime;
     };
 
-    const lifecycleEvents = this.lifecycleEvents;
-    lifecycleEvents.tickEvent.addListener(this.onTickEvent);
+    this.lifecycleEventEmitter.tickEvent.addListener(this.onTickEvent);
   }
 
   dispose(engine: Engine) {
     Assert.mustBeTrue(this.onTickEvent !== undefined);
     if (this.onTickEvent !== undefined) {
-      const lifecycleEvents = this.lifecycleEvents;
-      lifecycleEvents.tickEvent.removeListener(this.onTickEvent);
+      this.lifecycleEventEmitter.tickEvent.removeListener(this.onTickEvent);
     }
   }
 }

--- a/src/lib/Profiles/Core/registerCoreProfile.ts
+++ b/src/lib/Profiles/Core/registerCoreProfile.ts
@@ -25,7 +25,11 @@ import { IntegerValue } from './Values/IntegerValue.js';
 import * as StringNodes from './Values/StringNodes.js';
 import { StringValue } from './Values/StringValue.js';
 
-export function registerCoreProfile(registry: Registry, ilogger: ILogger = new DefaultLogger(), iLifeCycle: ILifecycleEventEmitter = new ManualLifecycleEventEmitter()) {
+export function registerCoreProfile(
+  registry: Registry,
+  logger: ILogger = new DefaultLogger(),
+  lifecycleEventEmitter: ILifecycleEventEmitter = new ManualLifecycleEventEmitter()
+) {
   const { nodes, values } = registry;
 
   // pull in value type nodes
@@ -42,14 +46,14 @@ export function registerCoreProfile(registry: Registry, ilogger: ILogger = new D
 
   // actions
 
-  nodes.register(DebugLog.Description(ilogger));
+  nodes.register(DebugLog.Description(logger));
   nodes.register(AssertExpectTrue.Description);
 
   // events
 
-  nodes.register(LifecycleOnStart.Description(iLifeCycle));
-  nodes.register(LifecycleOnEnd.Description(iLifeCycle));
-  nodes.register(LifecycleOnTick.Description(iLifeCycle));
+  nodes.register(LifecycleOnStart.Description(lifecycleEventEmitter));
+  nodes.register(LifecycleOnEnd.Description(lifecycleEventEmitter));
+  nodes.register(LifecycleOnTick.Description(lifecycleEventEmitter));
 
   // flow control
 

--- a/src/lib/Profiles/Scene/Queries/GetSceneProperty.ts
+++ b/src/lib/Profiles/Scene/Queries/GetSceneProperty.ts
@@ -31,10 +31,9 @@ export class GetSceneProperty extends ImmediateNode {
       [new Socket('string', 'jsonPath')],
       [new Socket(valueTypeName, 'value')],
       () => {
-        const sceneGraph = this.scene;
         this.writeOutput(
           'value',
-          sceneGraph.getProperty(this.readInput('jsonPath'), valueTypeName)
+          this.scene.getProperty(this.readInput('jsonPath'), valueTypeName)
         );
       }
     );

--- a/src/lib/Profiles/Scene/registerSceneProfile.ts
+++ b/src/lib/Profiles/Scene/registerSceneProfile.ts
@@ -44,8 +44,12 @@ export function registerSceneProfile(registry: Registry, scene: IScene) {
 
   // actions
   const allValueTypeNames = values.getAllNames();
-  nodes.register(...SetSceneProperty.GetDescriptions(scene, ...allValueTypeNames));
-  nodes.register(...GetSceneProperty.GetDescriptions(scene, ...allValueTypeNames));
+  nodes.register(
+    ...SetSceneProperty.GetDescriptions(scene, ...allValueTypeNames)
+  );
+  nodes.register(
+    ...GetSceneProperty.GetDescriptions(scene, ...allValueTypeNames)
+  );
 
   const newValueTypeNames = ['vec2', 'vec3', 'vec4', 'quat', 'euler', 'color'];
 


### PR DESCRIPTION
clean up of the removal of the abstraction registry.  Just clean up variable naming.  prettier formatting fixes.  update documentation to mention that the abstraction library was removed.