### PR TITLE
adopt destructured alternative constructors.

### DIFF
--- a/packages/core/src/Nodes/AsyncNode.ts
+++ b/packages/core/src/Nodes/AsyncNode.ts
@@ -10,8 +10,8 @@ export class AsyncNode extends Node {
   constructor(
     description: NodeDescription,
     graph: Graph,
-    inputSockets: Socket[],
-    outputSockets: Socket[]
+    inputSockets: Socket[] = [],
+    outputSockets: Socket[] = []
   ) {
     super(description, graph, inputSockets, outputSockets);
     // must have at least one input flow socket
@@ -36,5 +36,21 @@ export class AsyncNode extends Node {
 
   dispose() {
     throw new Error('not implemented');
+  }
+}
+
+export class AsyncNode2 extends AsyncNode {
+  constructor(properties: {
+    description: NodeDescription;
+    graph: Graph;
+    inputSockets?: Socket[];
+    outputSockets?: Socket[];
+  }) {
+    super(
+      properties.description,
+      properties.graph,
+      properties.inputSockets,
+      properties.outputSockets
+    );
   }
 }

--- a/packages/core/src/Nodes/EventNode.ts
+++ b/packages/core/src/Nodes/EventNode.ts
@@ -10,8 +10,8 @@ export class EventNode extends Node {
   constructor(
     description: NodeDescription,
     graph: Graph,
-    inputSockets: Socket[],
-    outputSockets: Socket[]
+    inputSockets: Socket[] = [],
+    outputSockets: Socket[] = []
   ) {
     super(description, graph, inputSockets, outputSockets);
     // no input flow sockets allowed.
@@ -33,5 +33,21 @@ export class EventNode extends Node {
   // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
   dispose(engine: Engine) {
     throw new Error('not implemented');
+  }
+}
+
+export class EventNode2 extends EventNode {
+  constructor(properties: {
+    description: NodeDescription;
+    graph: Graph;
+    inputSockets?: Socket[];
+    outputSockets?: Socket[];
+  }) {
+    super(
+      properties.description,
+      properties.graph,
+      properties.inputSockets,
+      properties.outputSockets
+    );
   }
 }

--- a/packages/core/src/Nodes/FlowNode.ts
+++ b/packages/core/src/Nodes/FlowNode.ts
@@ -9,8 +9,8 @@ export class FlowNode extends Node {
   constructor(
     description: NodeDescription,
     graph: Graph,
-    inputSockets: Socket[],
-    outputSockets: Socket[]
+    inputSockets: Socket[] = [],
+    outputSockets: Socket[] = []
   ) {
     // determine if this is an eval node
     super(description, graph, inputSockets, outputSockets);
@@ -24,5 +24,21 @@ export class FlowNode extends Node {
   // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
   triggered(fiber: Fiber, triggeringSocketName: string) {
     throw new Error('not implemented');
+  }
+}
+
+export class FlowNode2 extends FlowNode {
+  constructor(properties: {
+    description: NodeDescription;
+    graph: Graph;
+    inputSockets?: Socket[];
+    outputSockets?: Socket[];
+  }) {
+    super(
+      properties.description,
+      properties.graph,
+      properties.inputSockets,
+      properties.outputSockets
+    );
   }
 }

--- a/packages/core/src/Nodes/ImmediateNode.ts
+++ b/packages/core/src/Nodes/ImmediateNode.ts
@@ -8,8 +8,8 @@ export class ImmediateNode extends Node {
   constructor(
     description: NodeDescription,
     graph: Graph,
-    inputSockets: Socket[],
-    outputSockets: Socket[],
+    inputSockets: Socket[] = [],
+    outputSockets: Socket[] = [],
     public readonly exec: () => void
   ) {
     super(description, graph, inputSockets, outputSockets);
@@ -22,6 +22,24 @@ export class ImmediateNode extends Node {
     // must have no output flow sockets
     Assert.mustBeTrue(
       !this.outputSockets.some((socket) => socket.valueTypeName === 'flow')
+    );
+  }
+}
+
+export class ImmediateNode2 extends ImmediateNode {
+  constructor(properties: {
+    description: NodeDescription;
+    graph: Graph;
+    inputSockets?: Socket[];
+    outputSockets?: Socket[];
+    exec: () => void;
+  }) {
+    super(
+      properties.description,
+      properties.graph,
+      properties.inputSockets,
+      properties.outputSockets,
+      properties.exec
     );
   }
 }

--- a/packages/core/src/Nodes/Registry/NodeDescription.ts
+++ b/packages/core/src/Nodes/Registry/NodeDescription.ts
@@ -15,6 +15,27 @@ export class NodeDescription {
     public readonly typeName: string,
     public readonly category: NodeCategory,
     public readonly label: string,
-    public readonly factory: NodeFactory
+    public readonly factory: NodeFactory,
+    public readonly otherTypeNames: string[] = []
   ) {}
+}
+
+export class NodeDescription2 extends NodeDescription {
+  constructor(
+    public properties: {
+      typeName: string;
+      category: NodeCategory;
+      label: string;
+      factory: NodeFactory;
+      otherTypeNames?: string[];
+    }
+  ) {
+    super(
+      properties.typeName,
+      properties.category,
+      properties.label,
+      properties.factory,
+      properties.otherTypeNames
+    );
+  }
 }

--- a/packages/core/src/Profiles/Core/CustomEvents/OnCustomEvent.ts
+++ b/packages/core/src/Profiles/Core/CustomEvents/OnCustomEvent.ts
@@ -2,11 +2,11 @@ import { Assert } from '../../../Diagnostics/Assert';
 import { CustomEvent } from '../../../Events/CustomEvent';
 import { Engine } from '../../../Execution/Engine';
 import { Graph } from '../../../Graphs/Graph';
-import { EventNode } from '../../../Nodes/EventNode';
+import { EventNode2 } from '../../../Nodes/EventNode';
 import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
 
-export class OnCustomEvent extends EventNode {
+export class OnCustomEvent extends EventNode2 {
   public static GetDescription(graph: Graph, customEventId: string) {
     const customEvent = graph.customEvents[customEventId];
     return new NodeDescription(
@@ -22,11 +22,10 @@ export class OnCustomEvent extends EventNode {
     graph: Graph,
     public readonly customEvent: CustomEvent
   ) {
-    super(
+    super({
       description,
       graph,
-      [],
-      [
+      outputSockets: [
         new Socket('flow', 'flow'),
         ...customEvent.parameters.map(
           (parameter) =>
@@ -38,7 +37,7 @@ export class OnCustomEvent extends EventNode {
             )
         )
       ]
-    );
+    });
   }
   private onCustomEvent:
     | ((parameters: { [parameter: string]: any }) => void)

--- a/packages/core/src/Profiles/Core/CustomEvents/TriggerCustomEvent.ts
+++ b/packages/core/src/Profiles/Core/CustomEvents/TriggerCustomEvent.ts
@@ -1,11 +1,11 @@
 import { CustomEvent } from '../../../Events/CustomEvent';
 import { Fiber } from '../../../Execution/Fiber';
 import { Graph } from '../../../Graphs/Graph';
-import { FlowNode } from '../../../Nodes/FlowNode';
+import { FlowNode2 } from '../../../Nodes/FlowNode';
 import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
 
-export class TriggerCustomEvent extends FlowNode {
+export class TriggerCustomEvent extends FlowNode2 {
   public static GetDescription(graph: Graph, customEventId: string) {
     const customEvent = graph.customEvents[customEventId];
     return new NodeDescription(
@@ -22,10 +22,10 @@ export class TriggerCustomEvent extends FlowNode {
     graph: Graph,
     public readonly customEvent: CustomEvent
   ) {
-    super(
+    super({
       description,
       graph,
-      [
+      inputSockets: [
         new Socket('flow', 'flow'),
         ...customEvent.parameters.map(
           (parameter) =>
@@ -37,8 +37,8 @@ export class TriggerCustomEvent extends FlowNode {
             )
         )
       ],
-      [new Socket('flow', 'flow')]
-    );
+      outputSockets: [new Socket('flow', 'flow')]
+    });
   }
 
   triggered(fiber: Fiber, triggeringSocketName: string) {

--- a/packages/core/src/Profiles/Core/Flow/ForLoop.ts
+++ b/packages/core/src/Profiles/Core/Flow/ForLoop.ts
@@ -1,16 +1,19 @@
 import { Fiber } from '../../../Execution/Fiber';
 import { Graph } from '../../../Graphs/Graph';
 import { FlowNode } from '../../../Nodes/FlowNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
+import {
+  NodeDescription,
+  NodeDescription2
+} from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
 
 export class ForLoop extends FlowNode {
-  public static Description = new NodeDescription(
-    'flow/forLoop',
-    'Flow',
-    'For Loop',
-    (description, graph) => new ForLoop(description, graph)
-  );
+  public static Description = new NodeDescription2({
+    typeName: 'flow/forLoop',
+    category: 'Flow',
+    label: 'For Loop',
+    factory: (description, graph) => new ForLoop(description, graph)
+  });
 
   constructor(description: NodeDescription, graph: Graph) {
     super(

--- a/packages/core/src/Profiles/Core/Flow/Sequence.ts
+++ b/packages/core/src/Profiles/Core/Flow/Sequence.ts
@@ -1,7 +1,10 @@
 import { Fiber } from '../../../Execution/Fiber';
 import { Graph } from '../../../Graphs/Graph';
 import { FlowNode } from '../../../Nodes/FlowNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
+import {
+  NodeDescription,
+  NodeDescription2
+} from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
 
 // https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/Blueprints/UserGuide/flow/
@@ -11,12 +14,14 @@ export class Sequence extends FlowNode {
     const descriptions: NodeDescription[] = [];
     for (let numOutputs = 1; numOutputs < 10; numOutputs++) {
       descriptions.push(
-        new NodeDescription(
-          `flow/sequence/${numOutputs}`,
-          'Flow',
-          `Sequence ${numOutputs}`,
-          (description, graph) => new Sequence(description, graph, numOutputs)
-        )
+        new NodeDescription2({
+          typeName: `flow/sequence/${numOutputs}`,
+          category: 'Flow',
+          label: `Sequence ${numOutputs}`,
+          factory: (description, graph) =>
+            new Sequence(description, graph, numOutputs),
+          otherTypeNames: numOutputs === 3 ? ['flow/sequence'] : [] // old sequence node has 3 outputs
+        })
       );
     }
     return descriptions;

--- a/packages/core/src/Profiles/Core/Time/Delay.ts
+++ b/packages/core/src/Profiles/Core/Time/Delay.ts
@@ -1,19 +1,23 @@
 import { Engine } from '../../../Execution/Engine';
 import { Graph } from '../../../Graphs/Graph';
 import { AsyncNode } from '../../../Nodes/AsyncNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
+import {
+  NodeDescription,
+  NodeDescription2
+} from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
 
 // ASYNC - asynchronous evaluation
 // also called "delay"
 
 export class Delay extends AsyncNode {
-  public static Description = new NodeDescription(
-    'time/delay',
-    'Time',
-    'Delay',
-    (description, graph) => new Delay(description, graph)
-  );
+  public static Description = new NodeDescription2({
+    typeName: 'time/delay',
+    otherTypeNames: ['flow/delay'],
+    category: 'Time',
+    label: 'Delay',
+    factory: (description, graph) => new Delay(description, graph)
+  });
 
   constructor(description: NodeDescription, graph: Graph) {
     super(


### PR DESCRIPTION
This implements NodeDescription2, AsyncNode2, ImmediateNode2, EventNode2 and FlowNode2 which are just restructured versions of the same classes without the 2 postfix.  This allows for incremental adoption of destructuring - and then once it is done, we can combine the destructured classes into the main classes and remove the 2.

Fixes https://github.com/bhouston/behave-graph/issues/127

CC: @oveddan 