### PR TITLE
allow for old type names to resolve nodes, but use the new ones.

### DIFF
--- a/packages/core/src/Nodes/Registry/NodeTypeRegistry.ts
+++ b/packages/core/src/Nodes/Registry/NodeTypeRegistry.ts
@@ -12,12 +12,17 @@ export class NodeTypeRegistry {
   }
   register(...descriptions: Array<NodeDescription>) {
     descriptions.forEach((description) => {
-      if (description.typeName in this.typeNameToNodeDescriptions) {
-        throw new Error(
-          `already registered node type ${description.typeName} (string)`
-        );
-      }
-      this.typeNameToNodeDescriptions[description.typeName] = description;
+      description.otherTypeNames
+        .concat([description.typeName])
+        .forEach((typeName) => {
+          console.log('typeName', typeName);
+          if (typeName in this.typeNameToNodeDescriptions) {
+            throw new Error(
+              `already registered node type ${typeName} (string)`
+            );
+          }
+          this.typeNameToNodeDescriptions[typeName] = description;
+        });
     });
   }
 

--- a/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
+++ b/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
@@ -12,9 +12,11 @@ export function validateNodeRegistry(registry: Registry): string[] {
 
     // ensure node is registered correctly.
     if (node.description.typeName !== nodeTypeName) {
-      errorList.push(
-        `node with typeName '${node.description.typeName}' is registered under a different name '${nodeTypeName}'`
-      );
+      if (!node.description.otherTypeNames.includes(nodeTypeName)) {
+        errorList.push(
+          `node with typeName '${node.description.typeName}' is registered under a different name '${nodeTypeName}'`
+        );
+      }
     }
 
     if (!nodeTypeNameRegex.test(node.description.typeName)) {


### PR DESCRIPTION
This fixes this issue at least for node typeName changes.  It does not handle socket name changes.

fixes https://github.com/bhouston/behave-graph/issues/149
