### PR TITLE
Configuration

### DIFF
--- a/examples/export-node-spec/src/index.ts
+++ b/examples/export-node-spec/src/index.ts
@@ -55,17 +55,14 @@ async function main() {
 
           csvRow.push(input.name, input.valueType);
           if (input.valueType === 'flow') {
-            csvRow.push('', '');
+            csvRow.push('');
           } else if (input.defaultValue !== undefined) {
-            csvRow.push(
-              typeof input.defaultValue,
-              input.defaultValue.toString()
-            );
+            csvRow.push(input.defaultValue.toString());
           } else {
             csvRow.push('', '(undefined)');
           }
         } else {
-          csvRow.push('', '', '', '');
+          csvRow.push('', '', '');
         }
       }
       for (let i = 0; i < 5; i++) {

--- a/examples/graph-editor/src/graph.json
+++ b/examples/graph-editor/src/graph.json
@@ -1,65 +1,11 @@
 {
   "nodes": [
     {
-      "id": "7569b164-1b58-4520-bd1c-0ca1386c554b",
-      "type": "debug/log",
-      "metadata": {
-        "positionX": "-217",
-        "positionY": "413"
-      },
-      "parameters": {
-        "text": {
-          "value": "Finished"
-        }
-      }
-    },
-    {
-      "id": "9c8f417c-4a96-4be0-8b7b-5c0542ba3a0f",
-      "type": "lifecycle/onEnd",
-      "metadata": {
-        "positionX": "-430",
-        "positionY": "421"
-      },
-      "flows": {
-        "flow": {
-          "nodeId": "7569b164-1b58-4520-bd1c-0ca1386c554b",
-          "socket": "flow"
-        }
-      }
-    },
-    {
-      "id": "fb0d04f5-0915-4408-bee0-87b1f3931ea7",
-      "type": "debug/log",
-      "metadata": {
-        "positionX": "-287",
-        "positionY": "196"
-      },
-      "parameters": {
-        "text": {
-          "value": "Ticking"
-        }
-      }
-    },
-    {
-      "id": "1fe32e5d-e14e-455a-9a49-7c21a79dd9da",
-      "type": "lifecycle/onTick",
-      "metadata": {
-        "positionX": "-550",
-        "positionY": "168"
-      },
-      "flows": {
-        "flow": {
-          "nodeId": "fb0d04f5-0915-4408-bee0-87b1f3931ea7",
-          "socket": "flow"
-        }
-      }
-    },
-    {
       "id": "0",
       "type": "lifecycle/onStart",
       "metadata": {
-        "positionX": "-579",
-        "positionY": "-67"
+        "positionX": "2.1104424778760915",
+        "positionY": "-501.2300884955752"
       },
       "flows": {
         "flow": {
@@ -72,12 +18,12 @@
       "id": "1",
       "type": "debug/log",
       "metadata": {
-        "positionX": "-422",
-        "positionY": "-67"
+        "positionX": "225.32530973451327",
+        "positionY": "-502.2853097345133"
       },
       "parameters": {
         "text": {
-          "value": "Starting Sequence..."
+          "value": "Starting 10,000,000 iteration for-loop..."
         }
       },
       "flows": {
@@ -89,68 +35,87 @@
     },
     {
       "id": "2",
-      "type": "flow/sequence",
+      "type": "flow/forLoop",
       "metadata": {
-        "positionX": "-164",
-        "positionY": "-67"
+        "positionX": "612.0994690265486",
+        "positionY": "-497.00920353982303"
+      },
+      "parameters": {
+        "startIndex": {
+          "value": 0
+        },
+        "endIndex": {
+          "value": 10000000
+        }
       },
       "flows": {
-        "1": {
-          "nodeId": "3",
-          "socket": "flow"
-        },
-        "2": {
-          "nodeId": "4",
-          "socket": "flow"
-        },
-        "3": {
+        "loopBody": {
           "nodeId": "5",
+          "socket": "flow"
+        },
+        "completed": {
+          "nodeId": "7",
           "socket": "flow"
         }
       }
     },
     {
       "id": "3",
-      "type": "debug/log",
+      "type": "math/modulus/integer",
       "metadata": {
-        "positionX": "32",
-        "positionY": "-99"
+        "positionX": "1086.4569911504425",
+        "positionY": "-435.806371681416"
       },
       "parameters": {
-        "text": {
-          "value": "First Sequence Output!"
-        }
-      },
-      "flows": {
-        "flow": {
-          "nodeId": "6",
-          "socket": "flow"
+        "b": {
+          "value": 1000000
+        },
+        "a": {
+          "link": {
+            "nodeId": "2",
+            "socket": "index"
+          }
         }
       }
     },
     {
       "id": "4",
-      "type": "debug/log",
+      "type": "math/equal/integer",
       "metadata": {
-        "positionX": "26",
-        "positionY": "40"
+        "positionX": "1281.1808849557524",
+        "positionY": "-440.0272566371682"
       },
       "parameters": {
-        "text": {
-          "value": "Second Sequence Output!"
+        "b": {
+          "value": 0
+        },
+        "a": {
+          "link": {
+            "nodeId": "3",
+            "socket": "result"
+          }
         }
       }
     },
     {
       "id": "5",
-      "type": "debug/log",
+      "type": "flow/branch",
       "metadata": {
-        "positionX": "21",
-        "positionY": "179"
+        "positionX": "1497.0092035398231",
+        "positionY": "-548.7150442477877"
       },
       "parameters": {
-        "text": {
-          "value": "Third Sequence Output!"
+        "condition": {
+          "link": {
+            "nodeId": "4",
+            "socket": "result"
+          }
+        }
+      },
+      "flows": {
+        "true": {
+          "nodeId": "6",
+          "socket": "flow"
         }
       }
     },
@@ -158,12 +123,25 @@
       "id": "6",
       "type": "debug/log",
       "metadata": {
-        "positionX": "321",
-        "positionY": "-98"
+        "positionX": "1746.6046017699116",
+        "positionY": "-580.3716814159293"
       },
       "parameters": {
         "text": {
-          "value": "Downstream of First Sequence!"
+          "value": "1,000,000 more iterations..."
+        }
+      }
+    },
+    {
+      "id": "7",
+      "type": "debug/log",
+      "metadata": {
+        "positionX": "1125.642477876106",
+        "positionY": "-156.17274336283188"
+      },
+      "parameters": {
+        "text": {
+          "value": "Completed all iterations!"
         }
       }
     }

--- a/examples/three-viewer/public/graphs/scene/actions/FlashSuzanne.json
+++ b/examples/three-viewer/public/graphs/scene/actions/FlashSuzanne.json
@@ -21,11 +21,17 @@
       }
     },
     {
-      "type": "customEvent/trigger/0",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "1"
     },
     {
-      "type": "customEvent/onTriggered/0",
+      "type": "customEvent/onTriggered",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "2",
       "flows": {
         "flow": {
@@ -68,11 +74,17 @@
       }
     },
     {
-      "type": "customEvent/trigger/1",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 1
+      },
       "id": "5"
     },
     {
-      "type": "customEvent/onTriggered/1",
+      "type": "customEvent/onTriggered",
+      "configuration": {
+        "customEventId": 1
+      },
       "id": "6",
       "flows": {
         "flow": {
@@ -115,7 +127,10 @@
       }
     },
     {
-      "type": "customEvent/trigger/0",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "9"
     }
   ]

--- a/examples/three-viewer/public/graphs/scene/actions/Hierarchy.json
+++ b/examples/three-viewer/public/graphs/scene/actions/Hierarchy.json
@@ -21,11 +21,17 @@
       }
     },
     {
-      "type": "customEvent/trigger/0",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "1"
     },
     {
-      "type": "customEvent/onTriggered/0",
+      "type": "customEvent/onTriggered",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "2",
       "flows": {
         "flow": {
@@ -68,11 +74,17 @@
       }
     },
     {
-      "type": "customEvent/trigger/1",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 1
+      },
       "id": "5"
     },
     {
-      "type": "customEvent/onTriggered/1",
+      "type": "customEvent/onTriggered",
+      "configuration": {
+        "customEventId": 1
+      },
       "id": "6",
       "flows": {
         "flow": {
@@ -115,7 +127,10 @@
       }
     },
     {
-      "type": "customEvent/trigger/0",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "9"
     }
   ]

--- a/graphs/core/events/CustomEvents.json
+++ b/graphs/core/events/CustomEvents.json
@@ -17,11 +17,17 @@
       }
     },
     {
-      "type": "customEvent/trigger/0",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "1"
     },
     {
-      "type": "customEvent/onTriggered/0",
+      "type": "customEvent/onTriggered",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "2",
       "flows": {
         "flow": {

--- a/graphs/core/events/CustomEventsParameters.json
+++ b/graphs/core/events/CustomEventsParameters.json
@@ -24,7 +24,10 @@
       }
     },
     {
-      "type": "customEvent/trigger/0",
+      "type": "customEvent/trigger",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "1",
       "parameters": {
         "text": {
@@ -33,7 +36,10 @@
       }
     },
     {
-      "type": "customEvent/onTriggered/0",
+      "type": "customEvent/onTriggered",
+      "configuration": {
+        "customEventId": 0
+      },
       "id": "2",
       "flows": {
         "flow": {

--- a/graphs/core/flow/Sequence.json
+++ b/graphs/core/flow/Sequence.json
@@ -26,7 +26,10 @@
       }
     },
     {
-      "type": "flow/sequence/3",
+      "type": "flow/sequence",
+      "configuration": {
+        "numOutputs": 3
+      },
       "id": "2",
       "flows": {
         "1": {

--- a/graphs/core/flow/WaitAll.json
+++ b/graphs/core/flow/WaitAll.json
@@ -26,7 +26,10 @@
       }
     },
     {
-      "type": "flow/sequence/4",
+      "type": "flow/sequence",
+      "configuration": {
+        "numOutputs": 4
+      },
       "id": "2",
       "flows": {
         "1": {
@@ -108,7 +111,10 @@
       }
     },
     {
-      "type": "flow/waitAll/2",
+      "type": "flow/waitAll",
+      "configuration": {
+        "numInputs": 2
+      },
       "id": "7",
       "flows": {
         "flow": {

--- a/graphs/core/variables/FrameCounter.json
+++ b/graphs/core/variables/FrameCounter.json
@@ -19,7 +19,10 @@
       }
     },
     {
-      "type": "variable/get/0",
+      "type": "variable/get",
+      "configuration": {
+        "variableId": 0
+      },
       "id": "2"
     },
     {
@@ -38,7 +41,10 @@
       }
     },
     {
-      "type": "variable/set/0",
+      "type": "variable/set",
+      "configuration": {
+        "variableId": 0
+      },
       "id": "4",
       "parameters": {
         "value": {

--- a/graphs/core/variables/InitialValue.json
+++ b/graphs/core/variables/InitialValue.json
@@ -19,7 +19,10 @@
       }
     },
     {
-      "type": "variable/get/0",
+      "type": "variable/get",
+      "configuration": {
+        "variableId": 0
+      },
       "id": "1"
     },
     {

--- a/graphs/core/variables/SetGet.json
+++ b/graphs/core/variables/SetGet.json
@@ -19,7 +19,10 @@
       }
     },
     {
-      "type": "variable/set/0",
+      "type": "variable/set",
+      "configuration": {
+        "variableId": 0 
+      },
       "id": "1",
       "parameters": {
         "value": {
@@ -34,7 +37,10 @@
       }
     },
     {
-      "type": "variable/get/0",
+      "type": "variable/get",
+      "configuration": {
+        "variableId": 0 
+      },
       "id": "2"
     },
     {

--- a/packages/core/src/Diagnostics/Assert.ts
+++ b/packages/core/src/Diagnostics/Assert.ts
@@ -4,4 +4,9 @@ export class Assert {
       throw new Error(`failed assertion: ${msg}`);
     }
   }
+  static mustBeDefined(variable: any, msg = '') {
+    if (variable === undefined) {
+      throw new Error(`failed assertion: variable must be defined ${msg}`);
+    }
+  }
 }

--- a/packages/core/src/Graphs/Graph.ts
+++ b/packages/core/src/Graphs/Graph.ts
@@ -2,11 +2,6 @@ import { CustomEvent } from '../Events/CustomEvent';
 import { generateUuid } from '../generateUuid';
 import { Metadata } from '../Metadata';
 import { Node, NodeConfiguration } from '../Nodes/Node';
-import { NodeTypeRegistry } from '../Nodes/Registry/NodeTypeRegistry';
-import { OnCustomEvent } from '../Profiles/Core/CustomEvents/OnCustomEvent';
-import { TriggerCustomEvent } from '../Profiles/Core/CustomEvents/TriggerCustomEvent';
-import { VariableGet } from '../Profiles/Core/Variables/VariableGet';
-import { VariableSet } from '../Profiles/Core/Variables/VariableSet';
 import { Registry } from '../Registry';
 import { Variable } from '../Variables/Variable';
 // Purpose:
@@ -21,29 +16,10 @@ export class Graph {
   // TODO: think about whether I can replace this with an immutable strategy?  Rather than having this mutable?
   public readonly customEvents: { [id: string]: CustomEvent } = {};
   public metadata: Metadata = {};
-  public readonly dynamicNodeRegistry = new NodeTypeRegistry();
   public version = 0;
 
   constructor(public readonly registry: Registry) {}
 
-  updateDynamicNodeDescriptions() {
-    // delete existing nodes
-    this.dynamicNodeRegistry.clear();
-    // re-add variable nodes
-    for (const variableId in this.variables) {
-      this.dynamicNodeRegistry.register(
-        VariableGet.GetDescription(this, variableId),
-        VariableSet.GetDescription(this, variableId)
-      );
-    }
-    // re-add custom event nodes
-    for (const customEventId in this.customEvents) {
-      this.dynamicNodeRegistry.register(
-        OnCustomEvent.GetDescription(this, customEventId),
-        TriggerCustomEvent.GetDescription(this, customEventId)
-      );
-    }
-  }
   createNode(
     nodeTypeName: string,
     nodeId: string = generateUuid(),
@@ -57,9 +33,6 @@ export class Graph {
     let nodeDescription = undefined;
     if (this.registry.nodes.contains(nodeTypeName)) {
       nodeDescription = this.registry.nodes.get(nodeTypeName);
-    }
-    if (this.dynamicNodeRegistry.contains(nodeTypeName)) {
-      nodeDescription = this.dynamicNodeRegistry.get(nodeTypeName);
     }
     if (nodeDescription === undefined) {
       throw new Error(

--- a/packages/core/src/Graphs/Graph.ts
+++ b/packages/core/src/Graphs/Graph.ts
@@ -1,7 +1,7 @@
 import { CustomEvent } from '../Events/CustomEvent';
 import { generateUuid } from '../generateUuid';
 import { Metadata } from '../Metadata';
-import { Node } from '../Nodes/Node';
+import { Node, NodeConfiguration } from '../Nodes/Node';
 import { NodeTypeRegistry } from '../Nodes/Registry/NodeTypeRegistry';
 import { OnCustomEvent } from '../Profiles/Core/CustomEvents/OnCustomEvent';
 import { TriggerCustomEvent } from '../Profiles/Core/CustomEvents/TriggerCustomEvent';
@@ -44,7 +44,11 @@ export class Graph {
       );
     }
   }
-  createNode(nodeTypeName: string, nodeId: string = generateUuid()): Node {
+  createNode(
+    nodeTypeName: string,
+    nodeId: string = generateUuid(),
+    nodeConfiguration: NodeConfiguration = {}
+  ): Node {
     if (nodeId in this.nodes) {
       throw new Error(
         `can not create new node of type ${nodeTypeName} with id ${nodeId} as one with that id already exists.`
@@ -62,7 +66,11 @@ export class Graph {
         `no registered node descriptions with the typeName ${nodeTypeName}`
       );
     }
-    const node = nodeDescription.factory(nodeDescription, this);
+    const node = nodeDescription.factory(
+      nodeDescription,
+      this,
+      nodeConfiguration
+    );
     node.id = nodeId;
     this.nodes[nodeId] = node;
     node.inputs.forEach((socket) => {

--- a/packages/core/src/Graphs/IO/GraphJSON.ts
+++ b/packages/core/src/Graphs/IO/GraphJSON.ts
@@ -16,11 +16,15 @@ export type FlowsJSON = {
   [key: string]: LinkJSON;
 };
 
+export type NodeConfigurationJSON = {
+  [key: string]: ValueJSON;
+};
+
 export type NodeJSON = {
   label?: string;
   type: string;
   id: string;
-
+  configuration?: NodeConfigurationJSON;
   parameters?: NodeParametersJSON;
   flows?: FlowsJSON;
   metadata?: Metadata;

--- a/packages/core/src/Graphs/IO/NodeSpecJSON.ts
+++ b/packages/core/src/Graphs/IO/NodeSpecJSON.ts
@@ -11,11 +11,15 @@ export type OutputSocketSpecJSON = {
   name: string;
   valueType: string;
 };
-
+export type ConfigurationSpecJSON = {
+  name: string;
+  valueType: string;
+};
 export type NodeSpecJSON = {
   type: string;
   category: NodeCategory;
   label: string;
+  configuration: ConfigurationSpecJSON;
   inputs: InputSocketSpecJSON[];
   outputs: OutputSocketSpecJSON[];
 };

--- a/packages/core/src/Graphs/IO/NodeSpecJSON.ts
+++ b/packages/core/src/Graphs/IO/NodeSpecJSON.ts
@@ -14,12 +14,13 @@ export type OutputSocketSpecJSON = {
 export type ConfigurationSpecJSON = {
   name: string;
   valueType: string;
+  defaultValue: ValueJSON;
 };
 export type NodeSpecJSON = {
   type: string;
   category: NodeCategory;
   label: string;
-  configuration: ConfigurationSpecJSON;
+  configuration: ConfigurationSpecJSON[];
   inputs: InputSocketSpecJSON[];
   outputs: OutputSocketSpecJSON[];
 };

--- a/packages/core/src/Graphs/IO/readGraphFromJSON.ts
+++ b/packages/core/src/Graphs/IO/readGraphFromJSON.ts
@@ -33,9 +33,6 @@ export function readGraphFromJSON(
     readCustomEventsJSON(graph, graphJson.customEvents ?? []);
   }
 
-  // register node based on variables and custom events.
-  graph.updateDynamicNodeDescriptions();
-
   const nodesJson = graphJson?.nodes ?? [];
 
   if (nodesJson.length === 0) {

--- a/packages/core/src/Graphs/IO/writeGraphToJSON.ts
+++ b/packages/core/src/Graphs/IO/writeGraphToJSON.ts
@@ -6,6 +6,7 @@ import {
   LinkJSON,
   NodeJSON,
   NodeParameterJSON,
+  ValueJSON,
   VariableJSON
 } from './GraphJSON';
 
@@ -78,6 +79,13 @@ export function writeGraphToJSON(graph: Graph): GraphJSON {
     }
     if (Object.keys(node.metadata).length > 0) {
       nodeJson.metadata = node.metadata;
+    }
+    if (Object.keys(node.description.configuration).length > 0) {
+      const configurationJson: { [key: string]: ValueJSON } = {};
+      Object.keys(node.configuration).forEach((key) => {
+        configurationJson[key] = node.configuration[key];
+      });
+      nodeJson.configuration = configurationJson;
     }
 
     const parametersJson: NodeJSON['parameters'] = {};

--- a/packages/core/src/Graphs/IO/writeNodeSpecsToJSON.ts
+++ b/packages/core/src/Graphs/IO/writeNodeSpecsToJSON.ts
@@ -19,7 +19,8 @@ export function writeNodeSpecsToJSON(registry: Registry): NodeSpecJSON[] {
       category: node.description.category,
       label: node.description.label,
       inputs: [],
-      outputs: []
+      outputs: [],
+      configuration: []
     };
 
     node.inputs.forEach((inputSocket) => {

--- a/packages/core/src/Nodes/AsyncNode.ts
+++ b/packages/core/src/Nodes/AsyncNode.ts
@@ -2,7 +2,7 @@ import { Assert } from '../Diagnostics/Assert';
 import { Engine } from '../Execution/Engine';
 import { Graph } from '../Graphs/Graph';
 import { Socket } from '../Sockets/Socket';
-import { Node } from './Node';
+import { Node, NodeConfiguration } from './Node';
 import { NodeDescription } from './Registry/NodeDescription';
 
 // async flow node with only a single flow input
@@ -11,9 +11,10 @@ export class AsyncNode extends Node {
     description: NodeDescription,
     graph: Graph,
     inputs: Socket[] = [],
-    outputs: Socket[] = []
+    outputs: Socket[] = [],
+    configuration: NodeConfiguration = {}
   ) {
-    super(description, graph, inputs, outputs);
+    super(description, graph, inputs, outputs, configuration);
     // must have at least one input flow socket
     Assert.mustBeTrue(
       this.inputs.some((socket) => socket.valueTypeName === 'flow')
@@ -40,17 +41,12 @@ export class AsyncNode extends Node {
 }
 
 export class AsyncNode2 extends AsyncNode {
-  constructor(properties: {
+  constructor(props: {
     description: NodeDescription;
     graph: Graph;
     inputs?: Socket[];
     outputs?: Socket[];
   }) {
-    super(
-      properties.description,
-      properties.graph,
-      properties.inputs,
-      properties.outputs
-    );
+    super(props.description, props.graph, props.inputs, props.outputs);
   }
 }

--- a/packages/core/src/Nodes/EventNode.ts
+++ b/packages/core/src/Nodes/EventNode.ts
@@ -2,7 +2,7 @@ import { Assert } from '../Diagnostics/Assert';
 import { Engine } from '../Execution/Engine';
 import { Graph } from '../Graphs/Graph';
 import { Socket } from '../Sockets/Socket';
-import { Node } from './Node';
+import { Node, NodeConfiguration } from './Node';
 import { NodeDescription } from './Registry/NodeDescription';
 
 // no flow inputs, always evaluated on startup
@@ -11,9 +11,10 @@ export class EventNode extends Node {
     description: NodeDescription,
     graph: Graph,
     inputs: Socket[] = [],
-    outputs: Socket[] = []
+    outputs: Socket[] = [],
+    configuration: NodeConfiguration = {}
   ) {
-    super(description, graph, inputs, outputs);
+    super(description, graph, inputs, outputs, configuration);
     // no input flow sockets allowed.
     Assert.mustBeTrue(
       !this.inputs.some((socket) => socket.valueTypeName === 'flow')
@@ -37,17 +38,19 @@ export class EventNode extends Node {
 }
 
 export class EventNode2 extends EventNode {
-  constructor(properties: {
+  constructor(props: {
     description: NodeDescription;
     graph: Graph;
     inputs?: Socket[];
     outputs?: Socket[];
+    configuration?: NodeConfiguration;
   }) {
     super(
-      properties.description,
-      properties.graph,
-      properties.inputs,
-      properties.outputs
+      props.description,
+      props.graph,
+      props.inputs,
+      props.outputs,
+      props.configuration
     );
   }
 }

--- a/packages/core/src/Nodes/FlowNode.ts
+++ b/packages/core/src/Nodes/FlowNode.ts
@@ -2,7 +2,7 @@ import { Assert } from '../Diagnostics/Assert';
 import { Fiber } from '../Execution/Fiber';
 import { Graph } from '../Graphs/Graph';
 import { Socket } from '../Sockets/Socket';
-import { Node } from './Node';
+import { Node, NodeConfiguration } from './Node';
 import { NodeDescription } from './Registry/NodeDescription';
 
 export class FlowNode extends Node {
@@ -10,10 +10,11 @@ export class FlowNode extends Node {
     description: NodeDescription,
     graph: Graph,
     inputs: Socket[] = [],
-    outputs: Socket[] = []
+    outputs: Socket[] = [],
+    configuration: NodeConfiguration = {}
   ) {
     // determine if this is an eval node
-    super(description, graph, inputs, outputs);
+    super(description, graph, inputs, outputs, configuration);
 
     // must have at least one input flow socket
     Assert.mustBeTrue(
@@ -28,17 +29,19 @@ export class FlowNode extends Node {
 }
 
 export class FlowNode2 extends FlowNode {
-  constructor(properties: {
+  constructor(props: {
     description: NodeDescription;
     graph: Graph;
     inputs?: Socket[];
     outputs?: Socket[];
+    configuration?: NodeConfiguration;
   }) {
     super(
-      properties.description,
-      properties.graph,
-      properties.inputs,
-      properties.outputs
+      props.description,
+      props.graph,
+      props.inputs,
+      props.outputs,
+      props.configuration
     );
   }
 }

--- a/packages/core/src/Nodes/ImmediateNode.ts
+++ b/packages/core/src/Nodes/ImmediateNode.ts
@@ -1,7 +1,7 @@
 import { Assert } from '../Diagnostics/Assert';
 import { Graph } from '../Graphs/Graph';
 import { Socket } from '../Sockets/Socket';
-import { Node } from './Node';
+import { Node, NodeConfiguration } from './Node';
 import { NodeDescription } from './Registry/NodeDescription';
 
 export class ImmediateNode extends Node {
@@ -10,9 +10,10 @@ export class ImmediateNode extends Node {
     graph: Graph,
     inputs: Socket[] = [],
     outputs: Socket[] = [],
-    public readonly exec: () => void
+    public readonly exec: () => void,
+    configuration: NodeConfiguration = {}
   ) {
-    super(description, graph, inputs, outputs);
+    super(description, graph, inputs, outputs, configuration);
 
     // must have no input flow sockets
     Assert.mustBeTrue(
@@ -27,7 +28,7 @@ export class ImmediateNode extends Node {
 }
 
 export class ImmediateNode2 extends ImmediateNode {
-  constructor(properties: {
+  constructor(props: {
     description: NodeDescription;
     graph: Graph;
     inputs?: Socket[];
@@ -35,11 +36,11 @@ export class ImmediateNode2 extends ImmediateNode {
     exec: () => void;
   }) {
     super(
-      properties.description,
-      properties.graph,
-      properties.inputs,
-      properties.outputs,
-      properties.exec
+      props.description,
+      props.graph,
+      props.inputs,
+      props.outputs,
+      props.exec
     );
   }
 }

--- a/packages/core/src/Nodes/Node.ts
+++ b/packages/core/src/Nodes/Node.ts
@@ -3,6 +3,10 @@ import { Metadata } from '../Metadata';
 import { Socket } from '../Sockets/Socket';
 import { NodeDescription } from './Registry/NodeDescription';
 
+export type NodeConfiguration = {
+  [key: string]: any;
+};
+
 export class Node {
   public id = '';
   public label = '';
@@ -12,7 +16,8 @@ export class Node {
     public readonly description: NodeDescription,
     public readonly graph: Graph,
     public readonly inputs: Socket[] = [],
-    public readonly outputs: Socket[] = []
+    public readonly outputs: Socket[] = [],
+    public readonly configuration: NodeConfiguration = {}
   ) {}
 
   // TODO: this may want to cache the values on the creation of the NodeEvalContext

--- a/packages/core/src/Nodes/Registry/NodeDescription.ts
+++ b/packages/core/src/Nodes/Registry/NodeDescription.ts
@@ -1,8 +1,19 @@
 import { Graph } from '../../Graphs/Graph';
-import { Node } from './../Node';
+import { Node, NodeConfiguration } from './../Node';
 import { NodeCategory } from './NodeCategory';
 
-export type NodeFactory = (entry: NodeDescription, graph: Graph) => Node;
+export type NodeFactory = (
+  entry: NodeDescription,
+  graph: Graph,
+  config: NodeConfiguration
+) => Node;
+
+export type NodeConfigurationDescription = {
+  [key: string]: {
+    valueType: string;
+    defaultValue?: any;
+  };
+};
 
 export function getNodeDescriptions(importWildcard: any) {
   return Object.keys(importWildcard)
@@ -17,7 +28,8 @@ export class NodeDescription {
     public readonly label: string = '',
     public readonly factory: NodeFactory,
     public readonly otherTypeNames: string[] = [],
-    public readonly helpDescription: string = ''
+    public readonly helpDescription: string = '',
+    public readonly configuration: NodeConfigurationDescription = {}
   ) {}
 }
 
@@ -27,6 +39,7 @@ export class NodeDescription2 extends NodeDescription {
       typeName: string;
       category: NodeCategory;
       label?: string;
+      configuration?: NodeConfigurationDescription;
       factory: NodeFactory;
       otherTypeNames?: string[];
       helpDescription?: string;
@@ -38,7 +51,8 @@ export class NodeDescription2 extends NodeDescription {
       properties.label,
       properties.factory,
       properties.otherTypeNames,
-      properties.helpDescription
+      properties.helpDescription,
+      properties.configuration
     );
   }
 }

--- a/packages/core/src/Profiles/Core/CustomEvents/TriggerCustomEvent.ts
+++ b/packages/core/src/Profiles/Core/CustomEvents/TriggerCustomEvent.ts
@@ -1,27 +1,34 @@
-import { CustomEvent } from '../../../Events/CustomEvent';
+import { NodeConfiguration } from 'packages/core/src/Nodes/Node';
+
 import { Fiber } from '../../../Execution/Fiber';
 import { Graph } from '../../../Graphs/Graph';
 import { FlowNode2 } from '../../../Nodes/FlowNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
+import {
+  NodeDescription,
+  NodeDescription2
+} from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
 
 export class TriggerCustomEvent extends FlowNode2 {
-  public static GetDescription(graph: Graph, customEventId: string) {
-    const customEvent = graph.customEvents[customEventId];
-    return new NodeDescription(
-      `customEvent/trigger/${customEvent.id}`,
-      'Action',
-      `Trigger ${customEvent.name}`,
-      (description, graph) =>
-        new TriggerCustomEvent(description, graph, customEvent)
-    );
-  }
+  public static Description = new NodeDescription2({
+    typeName: 'customEvent/trigger',
+    category: 'Action',
+    label: 'Trigger',
+    configuration: {
+      customEventId: {
+        valueType: 'number'
+      }
+    },
+    factory: (description, graph, configuration) =>
+      new TriggerCustomEvent(description, graph, configuration)
+  });
 
   constructor(
     description: NodeDescription,
     graph: Graph,
-    public readonly customEvent: CustomEvent
+    configuration: NodeConfiguration
   ) {
+    const customEvent = graph.customEvents[configuration.customEventId];
     super({
       description,
       graph,
@@ -37,15 +44,18 @@ export class TriggerCustomEvent extends FlowNode2 {
             )
         )
       ],
-      outputs: [new Socket('flow', 'flow')]
+      outputs: [new Socket('flow', 'flow')],
+      configuration
     });
   }
 
   triggered(fiber: Fiber, triggeringSocketName: string) {
+    const customEvent =
+      this.graph.customEvents[this.configuration.customEventId];
     const parameters: { [parameterName: string]: any } = {};
-    this.customEvent.parameters.forEach((parameterSocket) => {
+    customEvent.parameters.forEach((parameterSocket) => {
       parameters[parameterSocket.name] = this.readInput(parameterSocket.name);
     });
-    this.customEvent.eventEmitter.emit(parameters);
+    customEvent.eventEmitter.emit(parameters);
   }
 }

--- a/packages/core/src/Profiles/Core/Flow/Sequence.ts
+++ b/packages/core/src/Profiles/Core/Flow/Sequence.ts
@@ -1,3 +1,5 @@
+import { NodeConfiguration } from 'packages/core/src/Nodes/Node';
+
 import { Fiber } from '../../../Execution/Fiber';
 import { Graph } from '../../../Graphs/Graph';
 import { FlowNode } from '../../../Nodes/FlowNode';
@@ -10,29 +12,26 @@ import { Socket } from '../../../Sockets/Socket';
 // https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/Blueprints/UserGuide/flow/
 
 export class Sequence extends FlowNode {
-  public static GetDescriptions(): NodeDescription[] {
-    const descriptions: NodeDescription[] = [];
-    for (let numOutputs = 1; numOutputs < 10; numOutputs++) {
-      descriptions.push(
-        new NodeDescription2({
-          typeName: `flow/sequence/${numOutputs}`,
-          category: 'Flow',
-          label: `Sequence ${numOutputs}`,
-          factory: (description, graph) =>
-            new Sequence(description, graph, numOutputs),
-          otherTypeNames: numOutputs === 3 ? ['flow/sequence'] : [] // old sequence node has 3 outputs
-        })
-      );
-    }
-    return descriptions;
-  }
+  public static Description = new NodeDescription2({
+    typeName: 'flow/sequence',
+    category: 'Flow',
+    label: 'Sequence',
+    configuration: {
+      numOutputs: {
+        valueType: 'number'
+      }
+    },
+    factory: (description, graph, configuration) =>
+      new Sequence(description, graph, configuration)
+  });
 
   constructor(
     description: NodeDescription,
     graph: Graph,
-    private numOutputs: number
+    configuration: NodeConfiguration
   ) {
     const outputs: Socket[] = [];
+    const numOutputs = configuration.numOutputs;
     for (let outputIndex = 1; outputIndex <= numOutputs; outputIndex++) {
       outputs.push(new Socket('flow', `${outputIndex}`));
     }

--- a/packages/core/src/Profiles/Core/Values/BooleanConversions.test.ts
+++ b/packages/core/src/Profiles/Core/Values/BooleanConversions.test.ts
@@ -12,7 +12,7 @@ const makeEmptyGraph = () => {
 };
 
 const makeImmediateNodeWithEmptyGraph = (nodeDescription: NodeDescription) =>
-  nodeDescription.factory(intToBoolean, makeEmptyGraph()) as ImmediateNode;
+  nodeDescription.factory(intToBoolean, makeEmptyGraph(), {}) as ImmediateNode;
 
 const setInputSocketValue = (node: Node, socketName: string, value: any) => {
   const inputSocket = node.inputs.find((socket) => socket.name === socketName);

--- a/packages/core/src/Profiles/Core/Variables/VariableGet.ts
+++ b/packages/core/src/Profiles/Core/Variables/VariableGet.ts
@@ -1,4 +1,3 @@
-import { Assert } from '../../../Diagnostics/Assert';
 import { Graph } from '../../../Graphs/Graph';
 import { ImmediateNode } from '../../../Nodes/ImmediateNode';
 import { NodeConfiguration } from '../../../Nodes/Node';
@@ -7,6 +6,7 @@ import {
   NodeDescription2
 } from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
+import { Variable } from '../../../Variables/Variable';
 
 export class VariableGet extends ImmediateNode {
   public static Description = new NodeDescription2({
@@ -27,8 +27,9 @@ export class VariableGet extends ImmediateNode {
     graph: Graph,
     configuration: NodeConfiguration
   ) {
-    Assert.mustBeDefined(configuration.variableId);
-    const variable = graph.variables[configuration.variableId];
+    const variable =
+      graph.variables[configuration.variableId] ||
+      new Variable('-1', 'undefined', 'string', '');
     super(
       description,
       graph,

--- a/packages/core/src/Profiles/Core/Variables/VariableGet.ts
+++ b/packages/core/src/Profiles/Core/Variables/VariableGet.ts
@@ -1,25 +1,34 @@
+import { Assert } from '../../../Diagnostics/Assert';
 import { Graph } from '../../../Graphs/Graph';
 import { ImmediateNode } from '../../../Nodes/ImmediateNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
+import { NodeConfiguration } from '../../../Nodes/Node';
+import {
+  NodeDescription,
+  NodeDescription2
+} from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
-import { Variable } from '../../../Variables/Variable';
 
 export class VariableGet extends ImmediateNode {
-  public static GetDescription(graph: Graph, variableId: string) {
-    const variable = graph.variables[variableId];
-    return new NodeDescription(
-      `variable/get/${variable.id}`,
-      'Query',
-      '', // these nodes have no name in Unreal Engine Blueprints
-      (description, graph) => new VariableGet(description, graph, variable)
-    );
-  }
+  public static Description = new NodeDescription2({
+    typeName: 'variable/get',
+    category: 'Query',
+    label: 'Get',
+    configuration: {
+      variableId: {
+        valueType: 'number'
+      }
+    },
+    factory: (description, graph, configuration) =>
+      new VariableGet(description, graph, configuration)
+  });
 
   constructor(
     description: NodeDescription,
     graph: Graph,
-    public readonly variable: Variable
+    configuration: NodeConfiguration
   ) {
+    Assert.mustBeDefined(configuration.variableId);
+    const variable = graph.variables[configuration.variableId];
     super(
       description,
       graph,
@@ -27,7 +36,8 @@ export class VariableGet extends ImmediateNode {
       [new Socket(variable.valueTypeName, 'value', undefined, variable.name)], // output socket label uses variable name like UE4, but name is value to avoid breaking graph when variable is renamed
       () => {
         this.writeOutput('value', variable.get());
-      }
+      },
+      configuration
     );
   }
 }

--- a/packages/core/src/Profiles/Core/Variables/VariableSet.ts
+++ b/packages/core/src/Profiles/Core/Variables/VariableSet.ts
@@ -1,11 +1,28 @@
+import { NodeConfiguration } from 'packages/core/src/Nodes/Node';
+
+import { Assert } from '../../../Diagnostics/Assert';
 import { Fiber } from '../../../Execution/Fiber';
 import { Graph } from '../../../Graphs/Graph';
 import { FlowNode } from '../../../Nodes/FlowNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
+import {
+  NodeDescription,
+  NodeDescription2
+} from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
-import { Variable } from '../../../Variables/Variable';
-
 export class VariableSet extends FlowNode {
+  public static Description = new NodeDescription2({
+    typeName: 'variable/set',
+    category: 'Action',
+    label: 'Set',
+    configuration: {
+      variableId: {
+        valueType: 'number'
+      }
+    },
+    factory: (description, graph, configuration) =>
+      new VariableSet(description, graph, configuration)
+  });
+
   public static GetDescription(graph: Graph, variableId: string) {
     const variable = graph.variables[variableId];
     return new NodeDescription(
@@ -19,8 +36,11 @@ export class VariableSet extends FlowNode {
   constructor(
     description: NodeDescription,
     graph: Graph,
-    public readonly variable: Variable
+    configuration: NodeConfiguration
   ) {
+    Assert.mustBeDefined(configuration.variableId);
+    const variable = graph.variables[configuration.variableId];
+
     super(
       description,
       graph,
@@ -28,12 +48,15 @@ export class VariableSet extends FlowNode {
         new Socket('flow', 'flow'),
         new Socket(variable.valueTypeName, 'value', undefined, variable.name) // variable name is a label so variable can be renamed without breaking graph.
       ],
-      [new Socket('flow', 'flow')]
+      [new Socket('flow', 'flow')],
+      configuration
     );
   }
 
   triggered(fiber: Fiber, triggeredSocketName: string) {
-    this.variable.set(this.readInput('value'));
+    const variable = this.graph.variables[this.configuration.variableId];
+
+    variable.set(this.readInput('value'));
     fiber.commit(this, 'flow');
   }
 }

--- a/packages/core/src/Profiles/Core/Variables/VariableSet.ts
+++ b/packages/core/src/Profiles/Core/Variables/VariableSet.ts
@@ -1,14 +1,13 @@
-import { NodeConfiguration } from 'packages/core/src/Nodes/Node';
-
-import { Assert } from '../../../Diagnostics/Assert';
 import { Fiber } from '../../../Execution/Fiber';
 import { Graph } from '../../../Graphs/Graph';
 import { FlowNode } from '../../../Nodes/FlowNode';
+import { NodeConfiguration } from '../../../Nodes/Node';
 import {
   NodeDescription,
   NodeDescription2
 } from '../../../Nodes/Registry/NodeDescription';
 import { Socket } from '../../../Sockets/Socket';
+import { Variable } from '../../../Variables/Variable';
 export class VariableSet extends FlowNode {
   public static Description = new NodeDescription2({
     typeName: 'variable/set',
@@ -33,13 +32,16 @@ export class VariableSet extends FlowNode {
     );
   }
 
+  private readonly variable: Variable;
+
   constructor(
     description: NodeDescription,
     graph: Graph,
     configuration: NodeConfiguration
   ) {
-    Assert.mustBeDefined(configuration.variableId);
-    const variable = graph.variables[configuration.variableId];
+    const variable =
+      graph.variables[configuration.variableId] ||
+      new Variable('-1', 'undefined', 'string', '');
 
     super(
       description,
@@ -51,12 +53,11 @@ export class VariableSet extends FlowNode {
       [new Socket('flow', 'flow')],
       configuration
     );
+    this.variable = variable;
   }
 
   triggered(fiber: Fiber, triggeredSocketName: string) {
-    const variable = this.graph.variables[this.configuration.variableId];
-
-    variable.set(this.readInput('value'));
+    this.variable.set(this.readInput('value'));
     fiber.commit(this, 'flow');
   }
 }

--- a/packages/core/src/Profiles/Core/registerCoreProfile.ts
+++ b/packages/core/src/Profiles/Core/registerCoreProfile.ts
@@ -5,6 +5,8 @@ import { DefaultLogger } from './Abstractions/Drivers/DefaultLogger';
 import { ManualLifecycleEventEmitter } from './Abstractions/Drivers/ManualLifecycleEventEmitter';
 import { ILifecycleEventEmitter } from './Abstractions/ILifecycleEventEmitter';
 import { ILogger } from './Abstractions/ILogger';
+import { OnCustomEvent } from './CustomEvents/OnCustomEvent';
+import { TriggerCustomEvent } from './CustomEvents/TriggerCustomEvent';
 import { ExpectTrue as AssertExpectTrue } from './Debug/AssertExpectTrue';
 import { Log as DebugLog } from './Debug/DebugLog';
 import { Branch } from './Flow/Branch';
@@ -34,6 +36,8 @@ import * as IntegerNodes from './Values/IntegerNodes';
 import { IntegerValue } from './Values/IntegerValue';
 import * as StringNodes from './Values/StringNodes';
 import { StringValue } from './Values/StringValue';
+import { VariableGet } from './Variables/VariableGet';
+import { VariableSet } from './Variables/VariableSet';
 
 export function registerCoreProfile(
   registry: Registry,
@@ -53,6 +57,16 @@ export function registerCoreProfile(
   nodes.register(...getNodeDescriptions(BooleanNodes));
   nodes.register(...getNodeDescriptions(IntegerNodes));
   nodes.register(...getNodeDescriptions(FloatNodes));
+
+  // custom events
+
+  nodes.register(OnCustomEvent.Description);
+  nodes.register(TriggerCustomEvent.Description);
+
+  // variables
+
+  nodes.register(VariableGet.Description);
+  nodes.register(VariableSet.Description);
 
   // complex logic
 
@@ -79,14 +93,14 @@ export function registerCoreProfile(
   nodes.register(Branch.Description);
   nodes.register(FlipFlop.Description);
   nodes.register(ForLoop.Description);
-  nodes.register(...Sequence.GetDescriptions());
+  nodes.register(Sequence.Description);
   nodes.register(Debounce.Description);
   nodes.register(Throttle.Description);
   nodes.register(DoN.Description);
   nodes.register(DoOnce.Description);
   nodes.register(Gate.Description);
   nodes.register(MultiGate.Description);
-  nodes.register(...WaitAll.GetDescriptions());
+  nodes.register(WaitAll.Description);
   nodes.register(Counter.Description);
 
   // string converters


### PR DESCRIPTION
This adopts the convention that nodes now have a "configuration" section that is for non-run-time parameters.

For example, Sequence node can have variable number of outputs.  Now you can specify numOutputs for sequence in its configuration.

Here is the list of nodes that currently support configuration:
* Sequence: numOutputs
* WaitAll: numInputs
* VariableSet: variableId
* VariableGet: variableId
* CustomEvent Trigger: customEventId
* CustomEvent On Trigger: customEventId


For example this:
```json
   {
       "type": "customEvent/trigger/0",
       "id": "1"
     },
```

Becomes this:
```json
  {
       "type": "customEvent/trigger",
       "configuration": {
         "customEventId": 0
       },
       "id": "9"
     }
```