### PR TITLE
Switch from requiring dependencies at definition time to using at runtime dependency injection

### DIFF
--- a/examples/exec-graph/src/index.ts
+++ b/examples/exec-graph/src/index.ts
@@ -9,6 +9,8 @@ import {
   parseSafeFloat,
   readGraphFromJSON,
   registerCoreProfile,
+  registerLifecycleEventEmitter,
+  registerLogger,
   registerSceneProfile,
   Registry,
   validateGraph,
@@ -35,8 +37,13 @@ async function execGraph({
   const registry = new Registry();
   const manualLifecycleEventEmitter = new ManualLifecycleEventEmitter();
   const logger = new DefaultLogger();
-  registerCoreProfile(registry, logger, manualLifecycleEventEmitter);
+  registerCoreProfile(registry);
   registerSceneProfile(registry);
+  registerLogger(registry.dependencies, logger);
+  registerLifecycleEventEmitter(
+    registry.dependencies,
+    manualLifecycleEventEmitter
+  );
 
   const graphJsonPath = jsonPattern;
   Logger.verbose(`reading behavior graph: ${graphJsonPath}`);

--- a/examples/three-viewer/src/ThreeScene.ts
+++ b/examples/three-viewer/src/ThreeScene.ts
@@ -139,4 +139,11 @@ export class ThreeScene implements IScene {
   ): void {
     throw new Error('Method not implemented.');
   }
+
+  removeOnClickedListener(
+    jsonPath: string,
+    callback: (jsonPath: string) => void
+  ): void {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/examples/three-viewer/src/index.ts
+++ b/examples/three-viewer/src/index.ts
@@ -6,6 +6,8 @@ import {
   ManualLifecycleEventEmitter,
   readGraphFromJSON,
   registerCoreProfile,
+  registerLifecycleEventEmitter,
+  registerLogger,
   registerSceneProfile,
   Registry,
   validateGraph,
@@ -68,8 +70,13 @@ async function main() {
 
   const { threeScene, gltf } = await loadThreeScene();
 
-  registerCoreProfile(registry, logger, manualLifecycleEventEmitter);
+  registerCoreProfile(registry);
   registerSceneProfile(registry, threeScene);
+  registerLogger(registry.dependencies, logger);
+  registerLifecycleEventEmitter(
+    registry.dependencies,
+    manualLifecycleEventEmitter
+  );
 
   const graphJsonPath = publicImageUrl(
     `/graphs/scene/actions/SpinningSuzanne.json`

--- a/examples/three-viewer/src/index.ts
+++ b/examples/three-viewer/src/index.ts
@@ -8,6 +8,7 @@ import {
   registerCoreProfile,
   registerLifecycleEventEmitter,
   registerLogger,
+  registerSceneDependency,
   registerSceneProfile,
   Registry,
   validateGraph,
@@ -71,7 +72,7 @@ async function main() {
   const { threeScene, gltf } = await loadThreeScene();
 
   registerCoreProfile(registry);
-  registerSceneProfile(registry, threeScene);
+  registerSceneProfile(registry);
   registerLogger(registry.dependencies, logger);
   registerLifecycleEventEmitter(
     registry.dependencies,
@@ -88,6 +89,7 @@ async function main() {
   Logger.verbose(`reading behavior graph: ${graphJsonPath}`);
   const graphFetchResponse = await fetch(graphJsonPath);
   const graphJson = await graphFetchResponse.json();
+  registerSceneDependency(registry.dependencies, threeScene);
   const graph = readGraphFromJSON(graphJson, registry);
   graph.name = graphJsonPath;
 

--- a/packages/core/src/Graphs/Graph.ts
+++ b/packages/core/src/Graphs/Graph.ts
@@ -3,7 +3,7 @@ import { generateUuid } from '../generateUuid';
 import { Metadata } from '../Metadata';
 import { NodeConfiguration } from '../Nodes/Node';
 import { INode } from '../Nodes/NodeInstance';
-import { Registry } from '../Registry';
+import { IRegistry, Registry } from '../Registry';
 import { Variable } from '../Variables/Variable';
 // Purpose:
 //  - stores the node graph
@@ -12,6 +12,7 @@ export interface IGraphApi {
   readonly variables: { [id: string]: Variable };
   readonly customEvents: { [id: string]: CustomEvent };
   readonly values: Registry['values'];
+  readonly getDependency: <T>(id: string) => T;
 }
 
 export class Graph {
@@ -25,13 +26,14 @@ export class Graph {
   public metadata: Metadata = {};
   public version = 0;
 
-  constructor(public readonly registry: Registry) {}
+  constructor(public readonly registry: IRegistry) {}
 
   makeApi(): IGraphApi {
     return {
       variables: this.variables,
       customEvents: this.customEvents,
-      values: this.registry.values
+      values: this.registry.values,
+      getDependency: (id: string) => this.registry.dependencies.get(id)
     };
   }
 

--- a/packages/core/src/Nodes/AsyncNode.ts
+++ b/packages/core/src/Nodes/AsyncNode.ts
@@ -102,6 +102,6 @@ export class AsyncNodeInstance<TAsyncNodeDef extends IAsyncNodeDefinition>
     });
   };
   dispose = () => {
-    this.state = this.disposeInner({ state: this.state });
+    this.state = this.disposeInner({ state: this.state, graph: this.graph });
   };
 }

--- a/packages/core/src/Nodes/EventNode.ts
+++ b/packages/core/src/Nodes/EventNode.ts
@@ -103,7 +103,8 @@ export class EventNodeInstance<TEventNodeDef extends IEventNodeDefinition>
 
   dispose(): void {
     this.disposeInner({
-      state: this.state
+      state: this.state,
+      graph: this.graph
     });
   }
 }

--- a/packages/core/src/Nodes/NodeDefinitions.ts
+++ b/packages/core/src/Nodes/NodeDefinitions.ts
@@ -35,7 +35,7 @@ export interface IHasNodeFactory {
   readonly nodeFactory: NodeFactory;
 }
 
-export interface INodeDefinitionBase<
+export interface INodeDefinition<
   TInput extends SocketsDefinition = SocketsDefinition,
   TOutput extends SocketsDefinition = SocketsDefinition,
   TConfig extends NodeConfigurationDescription = NodeConfigurationDescription
@@ -51,18 +51,10 @@ export interface INodeDefinitionBase<
   configuration?: TConfig;
 }
 
-export interface INodeDefinition<
-  TInput extends SocketsDefinition,
-  TOutput extends SocketsDefinition,
-  TConfig extends NodeConfigurationDescription
-> extends INodeDefinitionBase<TInput, TOutput, TConfig> {
-  in: TInput;
-  out: TOutput;
-  configuration?: TConfig;
-}
-
 export type SocketNames<TSockets extends SocketsDefinition> =
   TSockets extends SocketsMap ? keyof TSockets : any;
+
+export type Dependencies = any | undefined;
 
 export type TriggeredFn<
   TInput extends SocketsDefinition = SocketsDefinition,
@@ -125,7 +117,7 @@ export interface IHasInit<
 }
 
 export interface IHasDispose<TState> {
-  dispose: (params: { state: TState }) => StateReturn<TState>;
+  dispose: (params: { state: TState; graph: IGraphApi }) => StateReturn<TState>;
 }
 
 export interface IFlowNodeDefinition<
@@ -148,7 +140,7 @@ export interface IAsyncNodeDefinition<
     IHasTriggered<TInput, TOutput, TState>,
     IHasDispose<TState> {}
 
-type OmitFactoryAndType<T extends INodeDefinitionBase> = Omit<
+type OmitFactoryAndType<T extends INodeDefinition> = Omit<
   T,
   'nodeFactory' | 'nodeType'
 >;

--- a/packages/core/src/Nodes/NodeInstance.ts
+++ b/packages/core/src/Nodes/NodeInstance.ts
@@ -14,7 +14,7 @@ export enum NodeType {
 }
 
 export interface INode {
-  readonly id: string;
+  id: string;
   readonly inputs: Socket[];
   readonly outputs: Socket[];
   readonly graph: IGraphApi;

--- a/packages/core/src/Nodes/Registry/DependenciesRegistry.ts
+++ b/packages/core/src/Nodes/Registry/DependenciesRegistry.ts
@@ -1,0 +1,18 @@
+export class DependenciesRegistry {
+  private readonly registryKeyToDependency: { [key: string]: any } = {};
+
+  register(key: string, dependency: any) {
+    this.registryKeyToDependency[key] = dependency;
+  }
+
+  get<T>(key: string): T {
+    if (!(key in this.registryKeyToDependency)) {
+      throw new Error(`can not find depenency with name '${key}`);
+    }
+    return this.registryKeyToDependency[key];
+  }
+
+  getAllNames(): string[] {
+    return Object.keys(this.registryKeyToDependency);
+  }
+}

--- a/packages/core/src/Nodes/Registry/NodeDescription.ts
+++ b/packages/core/src/Nodes/Registry/NodeDescription.ts
@@ -1,7 +1,7 @@
 import { IGraphApi } from '../../Graphs/Graph';
 import {
   IHasNodeFactory,
-  INodeDefinitionBase,
+  INodeDefinition,
   NodeFactory
 } from '../NodeDefinitions';
 import { INode } from '../NodeInstance';
@@ -16,9 +16,9 @@ export type NodeConfigurationDescription = {
 };
 
 export function getNodeDescriptions(importWildcard: {
-  [key: string]: INodeDefinitionBase;
-}): INodeDefinitionBase[] {
-  return Object.values(importWildcard) as INodeDefinitionBase[];
+  [key: string]: INodeDefinition;
+}): INodeDefinition[] {
+  return Object.values(importWildcard) as INodeDefinition[];
 }
 
 export interface INodeDescription {

--- a/packages/core/src/Nodes/Registry/NodeTypeRegistry.ts
+++ b/packages/core/src/Nodes/Registry/NodeTypeRegistry.ts
@@ -1,7 +1,7 @@
-import { IHasNodeFactory, INodeDefinitionBase } from '../NodeDefinitions';
+import { IHasNodeFactory, INodeDefinition } from '../NodeDefinitions';
 
 type NodeDefinition = IHasNodeFactory &
-  Pick<INodeDefinitionBase, 'typeName' | 'otherTypeNames'>;
+  Pick<INodeDefinition, 'typeName' | 'otherTypeNames'>;
 
 export class NodeTypeRegistry {
   private readonly typeNameToNodeDescriptions: {

--- a/packages/core/src/Nodes/nodeFactory.ts
+++ b/packages/core/src/Nodes/nodeFactory.ts
@@ -2,7 +2,7 @@ import { IGraphApi } from '../Graphs/Graph';
 import { Socket } from '../Sockets/Socket';
 import { NodeConfiguration } from './Node';
 import {
-  INodeDefinitionBase,
+  INodeDefinition,
   NodeCategory,
   SocketsDefinition,
   SocketsList,
@@ -72,7 +72,7 @@ export const makeCommonProps = (
     helpDescription = '',
     label = ''
   }: Pick<
-    INodeDefinitionBase,
+    INodeDefinition,
     | 'typeName'
     | 'in'
     | 'out'

--- a/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnStart.ts
+++ b/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnStart.ts
@@ -13,35 +13,43 @@ const makeInitialState = (): State => ({
   onStartEvent: undefined
 });
 
-export const LifecycleOnStart = (
-  lifecycleEventEmitter: ILifecycleEventEmitter
-) =>
-  makeEventNodeDefinition({
-    typeName: 'lifecycle/onStart',
-    label: 'On Start',
-    category: NodeCategory.Event,
-    in: {},
-    out: {
-      flow: 'flow'
-    },
-    initialState: makeInitialState(),
-    init: ({ state, commit }) => {
-      Assert.mustBeTrue(state.onStartEvent === undefined);
-      const onStartEvent = () => {
-        commit('flow');
-      };
+export const lifecycleEventEmitterDependencyKey = 'lifecycleEventEmitter';
 
-      lifecycleEventEmitter.startEvent.addListener(onStartEvent);
+export const LifecycleOnStart = makeEventNodeDefinition({
+  typeName: 'lifecycle/onStart',
+  label: 'On Start',
+  category: NodeCategory.Event,
+  in: {},
+  out: {
+    flow: 'flow'
+  },
+  initialState: makeInitialState(),
+  init: ({ state, commit, graph: { getDependency } }) => {
+    Assert.mustBeTrue(state.onStartEvent === undefined);
+    const onStartEvent = () => {
+      commit('flow');
+    };
 
-      return {
-        onStartEvent
-      };
-    },
-    dispose: ({ state: { onStartEvent } }) => {
-      Assert.mustBeTrue(onStartEvent !== undefined);
-      if (onStartEvent)
-        lifecycleEventEmitter.startEvent.removeListener(onStartEvent);
+    const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
+      lifecycleEventEmitterDependencyKey
+    );
 
-      return {};
-    }
-  });
+    lifecycleEventEmitter.startEvent.addListener(onStartEvent);
+
+    return {
+      onStartEvent
+    };
+  },
+  dispose: ({ state: { onStartEvent }, graph: { getDependency } }) => {
+    Assert.mustBeTrue(onStartEvent !== undefined);
+
+    const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
+      lifecycleEventEmitterDependencyKey
+    );
+
+    if (onStartEvent)
+      lifecycleEventEmitter.startEvent.removeListener(onStartEvent);
+
+    return {};
+  }
+});

--- a/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnTick.ts
+++ b/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnTick.ts
@@ -4,6 +4,7 @@ import {
   NodeCategory
 } from '../../../Nodes/NodeDefinitions';
 import { ILifecycleEventEmitter } from '../Abstractions/ILifecycleEventEmitter';
+import { lifecycleEventEmitterDependencyKey } from './LifecycleOnStart';
 
 type State = {
   onTickEvent?: (() => void) | undefined;
@@ -13,41 +14,47 @@ const makeInitialState = (): State => ({
   onTickEvent: undefined
 });
 
-export const LifecycleOnTick = (
-  lifecycleEventEmitter: ILifecycleEventEmitter
-) =>
-  makeEventNodeDefinition({
-    typeName: 'lifecycle/onTick',
-    label: 'On Tick',
-    category: NodeCategory.Event,
-    in: {},
-    out: {
-      flow: 'flow',
-      deltaSeconds: 'float'
-    },
-    initialState: makeInitialState(),
-    init: ({ state, commit, write }) => {
-      Assert.mustBeTrue(state.onTickEvent === undefined);
-      let lastTickTime = Date.now();
-      const onTickEvent = () => {
-        const currentTime = Date.now();
-        const deltaSeconds = (currentTime - lastTickTime) * 0.001;
-        write('deltaSeconds', deltaSeconds);
-        commit('flow');
-        lastTickTime = currentTime;
-      };
+export const LifecycleOnTick = makeEventNodeDefinition({
+  typeName: 'lifecycle/onTick',
+  label: 'On Tick',
+  category: NodeCategory.Event,
+  in: {},
+  out: {
+    flow: 'flow',
+    deltaSeconds: 'float'
+  },
+  initialState: makeInitialState(),
+  init: ({ state, commit, write, graph: { getDependency } }) => {
+    Assert.mustBeTrue(state.onTickEvent === undefined);
+    let lastTickTime = Date.now();
+    const onTickEvent = () => {
+      const currentTime = Date.now();
+      const deltaSeconds = (currentTime - lastTickTime) * 0.001;
+      write('deltaSeconds', deltaSeconds);
+      commit('flow');
+      lastTickTime = currentTime;
+    };
 
-      lifecycleEventEmitter.tickEvent.addListener(onTickEvent);
+    const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
+      lifecycleEventEmitterDependencyKey
+    );
 
-      return {
-        onTickEvent
-      };
-    },
-    dispose: ({ state: { onTickEvent } }) => {
-      Assert.mustBeTrue(onTickEvent !== undefined);
-      if (onTickEvent)
-        lifecycleEventEmitter.tickEvent.removeListener(onTickEvent);
+    lifecycleEventEmitter.tickEvent.addListener(onTickEvent);
 
-      return {};
-    }
-  });
+    return {
+      onTickEvent
+    };
+  },
+  dispose: ({ state: { onTickEvent }, graph: { getDependency } }) => {
+    Assert.mustBeTrue(onTickEvent !== undefined);
+
+    const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
+      lifecycleEventEmitterDependencyKey
+    );
+
+    if (onTickEvent)
+      lifecycleEventEmitter.tickEvent.removeListener(onTickEvent);
+
+    return {};
+  }
+});

--- a/packages/core/src/Profiles/Core/registerCoreProfile.ts
+++ b/packages/core/src/Profiles/Core/registerCoreProfile.ts
@@ -1,15 +1,14 @@
 /* eslint-disable max-len */
+import { DependenciesRegistry } from '../../Nodes/Registry/DependenciesRegistry';
 import { getNodeDescriptions } from '../../Nodes/Registry/NodeDescription';
-import { Registry } from '../../Registry';
+import { IRegistry } from '../../Registry';
 import { ValueTypeRegistry } from '../../Values/ValueTypeRegistry';
-import { DefaultLogger } from './Abstractions/Drivers/DefaultLogger';
-import { ManualLifecycleEventEmitter } from './Abstractions/Drivers/ManualLifecycleEventEmitter';
 import { ILifecycleEventEmitter } from './Abstractions/ILifecycleEventEmitter';
 import { ILogger } from './Abstractions/ILogger';
 import { OnCustomEvent } from './CustomEvents/OnCustomEvent';
 import { TriggerCustomEvent } from './CustomEvents/TriggerCustomEvent';
 import { ExpectTrue as AssertExpectTrue } from './Debug/AssertExpectTrue';
-import { Log as DebugLog } from './Debug/DebugLog';
+import { Log as DebugLog, loggerDependencyKey } from './Debug/DebugLog';
 import { Branch } from './Flow/Branch';
 import { Counter } from './Flow/Counter';
 import { Debounce } from './Flow/Debounce';
@@ -23,7 +22,10 @@ import { Sequence } from './Flow/Sequence';
 import { Throttle } from './Flow/Throttle';
 import { WaitAll } from './Flow/WaitAll';
 import { LifecycleOnEnd } from './Lifecycle/LifecycleOnEnd';
-import { LifecycleOnStart } from './Lifecycle/LifecycleOnStart';
+import {
+  lifecycleEventEmitterDependencyKey,
+  LifecycleOnStart
+} from './Lifecycle/LifecycleOnStart';
 import { LifecycleOnTick } from './Lifecycle/LifecycleOnTick';
 import { Easing } from './Logic/Easing';
 import { registerSerializersForValueType } from './registerSerializersForValueType';
@@ -40,6 +42,20 @@ import { StringValue } from './Values/StringValue';
 import { VariableGet } from './Variables/VariableGet';
 import { VariableSet } from './Variables/VariableSet';
 
+export function registerLogger(
+  registry: DependenciesRegistry,
+  logger: ILogger
+) {
+  registry.register(loggerDependencyKey, logger);
+}
+
+export function registerLifecycleEventEmitter(
+  registry: DependenciesRegistry,
+  emitter: ILifecycleEventEmitter
+) {
+  registry.register(lifecycleEventEmitterDependencyKey, emitter);
+}
+
 export function registerCoreValueTypes(values: ValueTypeRegistry) {
   // pull in value type nodes
   values.register(BooleanValue);
@@ -49,9 +65,7 @@ export function registerCoreValueTypes(values: ValueTypeRegistry) {
 }
 
 export function registerCoreProfile(
-  registry: Registry,
-  logger: ILogger = new DefaultLogger(),
-  lifecycleEventEmitter: ILifecycleEventEmitter = new ManualLifecycleEventEmitter()
+  registry: Pick<IRegistry, 'nodes' | 'values'>
 ) {
   const { nodes, values } = registry;
 
@@ -79,14 +93,14 @@ export function registerCoreProfile(
 
   // actions
 
-  nodes.register(DebugLog.Description(logger));
+  nodes.register(DebugLog);
   nodes.register(AssertExpectTrue.Description);
 
   // events
 
-  nodes.register(LifecycleOnStart(lifecycleEventEmitter));
-  nodes.register(LifecycleOnEnd(lifecycleEventEmitter));
-  nodes.register(LifecycleOnTick(lifecycleEventEmitter));
+  nodes.register(LifecycleOnStart);
+  nodes.register(LifecycleOnEnd);
+  nodes.register(LifecycleOnTick);
 
   // time
 

--- a/packages/core/src/Profiles/Core/registerSerializersForValueType.ts
+++ b/packages/core/src/Profiles/Core/registerSerializersForValueType.ts
@@ -1,9 +1,9 @@
 import { makeInNOutFunctionDesc } from '../../Nodes/FunctionNode';
-import { Registry } from '../../Registry';
+import { IRegistry } from '../../Registry';
 import { toCamelCase } from '../../toCamelCase';
 
 export function registerSerializersForValueType(
-  registry: Registry,
+  registry: Pick<IRegistry, 'nodes' | 'values'>,
   valueTypeName: string
 ) {
   const camelCaseValueTypeName = toCamelCase(valueTypeName);

--- a/packages/core/src/Profiles/Scene/Abstractions/Drivers/DummyScene.ts
+++ b/packages/core/src/Profiles/Scene/Abstractions/Drivers/DummyScene.ts
@@ -41,6 +41,12 @@ export class DummyScene implements IScene {
     jsonPath: string,
     callback: (jsonPath: string) => void
   ): void {
-    throw new Error('Method not implemented.');
+    console.log('added on clicked listener');
+  }
+  removeOnClickedListener(
+    jsonPath: string,
+    callback: (jsonPath: string) => void
+  ): void {
+    console.log('removed on clicked listener');
   }
 }

--- a/packages/core/src/Profiles/Scene/Abstractions/IScene.ts
+++ b/packages/core/src/Profiles/Scene/Abstractions/IScene.ts
@@ -5,4 +5,8 @@ export interface IScene {
     jsonPath: string,
     callback: (jsonPath: string) => void
   ): void;
+  removeOnClickedListener(
+    jsonPath: string,
+    callback: (jsonPath: string) => void
+  ): void;
 }

--- a/packages/core/src/Profiles/Scene/Actions/SetSceneProperty.ts
+++ b/packages/core/src/Profiles/Scene/Actions/SetSceneProperty.ts
@@ -1,47 +1,23 @@
-import { Fiber } from '../../../Execution/Fiber';
-import { IGraphApi } from '../../../Graphs/Graph';
-import { FlowNode } from '../../../Nodes/FlowNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
-import { Socket } from '../../../Sockets/Socket';
-import { toCamelCase } from '../../../toCamelCase';
+import { makeFlowNodeDefinition } from '../../../Nodes/NodeDefinitions';
 import { IScene } from '../Abstractions/IScene';
 
-export class SetSceneProperty extends FlowNode {
-  public static GetDescriptions(scene: IScene, ...valueTypeNames: string[]) {
-    return valueTypeNames.map(
-      (valueTypeName) =>
-        new NodeDescription(
-          `scene/set/${valueTypeName}`,
-          'Action',
-          `Set Scene ${toCamelCase(valueTypeName)}`,
-          (description, graph) =>
-            new SetSceneProperty(description, graph, valueTypeName, scene)
-        )
-    );
-  }
-
-  constructor(
-    description: NodeDescription,
-    graph: IGraphApi,
-    public readonly valueTypeName: string,
-    private readonly scene: IScene
-  ) {
-    super(
-      description,
-      graph,
-      [
-        new Socket('flow', 'flow'),
-        new Socket('string', 'jsonPath'),
-        new Socket(valueTypeName, 'value')
-      ],
-      [new Socket('flow', 'flow')]
-    );
-  }
-
-  triggered(fiber: Fiber, triggeringSocketName: string) {
-    const scene = this.scene;
-    const value = this.readInput('value');
-    scene.setProperty(this.readInput('jsonPath'), this.valueTypeName, value);
-    fiber.commit(this, 'flow');
-  }
-}
+export const SetSceneProperty = (valueTypeNames: string[]) =>
+  valueTypeNames.map((valueTypeName) =>
+    makeFlowNodeDefinition({
+      typeName: `scene/set/${valueTypeName}`,
+      in: {
+        jsonPath: 'string',
+        value: valueTypeName,
+        flow: 'flow'
+      },
+      out: {
+        flow: 'flow'
+      },
+      initialState: undefined,
+      triggered: ({ commit, read, graph: { getDependency } }) => {
+        const scene = getDependency<IScene>('scene');
+        scene.setProperty(read('jsonPath'), valueTypeName, read('value'));
+        commit('flow');
+      }
+    })
+  );

--- a/packages/core/src/Profiles/Scene/Events/OnSceneNodeClick.ts
+++ b/packages/core/src/Profiles/Scene/Events/OnSceneNodeClick.ts
@@ -1,23 +1,57 @@
-import { IGraphApi } from '../../../Graphs/Graph';
-import { EventNode } from '../../../Nodes/EventNode';
-import { NodeDescription } from '../../../Nodes/Registry/NodeDescription';
-import { Socket } from '../../../Sockets/Socket';
+import { Assert } from '../../../Diagnostics/Assert';
+import {
+  makeEventNodeDefinition,
+  NodeCategory
+} from '../../../Nodes/NodeDefinitions';
+import { IScene } from '../Abstractions/IScene';
+
+type State = {
+  jsonPath?: string | undefined;
+  handleNodeClick?: ((jsonPath: string) => void) | undefined;
+};
+
+const initialState = (): State => ({});
 
 // very 3D specific.
-export class OnSceneNodeClick extends EventNode {
-  public static Description = new NodeDescription(
-    'scene/nodeClick',
-    'Event',
-    'On Node Click',
-    (description, graph) => new OnSceneNodeClick(description, graph)
-  );
+export const OnSceneNodeClick = makeEventNodeDefinition({
+  typeName: 'scene/nodeClick',
+  category: NodeCategory.Event,
+  in: {
+    jsonPath: 'string'
+  },
+  out: {
+    flow: 'flow'
+  },
+  initialState: initialState(),
+  init: ({ read, commit, graph: { getDependency } }) => {
+    const handleNodeClick = () => {
+      commit('flow');
+    };
 
-  constructor(description: NodeDescription, graph: IGraphApi) {
-    super(
-      description,
-      graph,
-      [],
-      [new Socket('flow', 'flow'), new Socket('float', 'nodeIndex')]
-    );
+    const jsonPath = read<string>('jsonPath');
+
+    const scene = getDependency<IScene>('scene');
+    scene.addOnClickedListener(jsonPath, handleNodeClick);
+
+    const state: State = {
+      handleNodeClick,
+      jsonPath
+    };
+
+    return state;
+  },
+  dispose: ({
+    state: { handleNodeClick, jsonPath },
+    graph: { getDependency }
+  }) => {
+    Assert.mustBeTrue(handleNodeClick !== undefined);
+    Assert.mustBeTrue(jsonPath !== undefined);
+
+    if (!jsonPath || !handleNodeClick) return {};
+
+    const scene = getDependency<IScene>('scene');
+    scene.removeOnClickedListener(jsonPath, handleNodeClick);
+
+    return {};
   }
-}
+});

--- a/packages/core/src/Profiles/Scene/registerSceneProfile.ts
+++ b/packages/core/src/Profiles/Scene/registerSceneProfile.ts
@@ -1,8 +1,7 @@
 /* eslint-disable max-len */
 import { getNodeDescriptions } from '../../Nodes/Registry/NodeDescription';
-import { Registry } from '../../Registry';
+import { IRegistry, Registry } from '../../Registry';
 import { registerSerializersForValueType } from '../Core/registerSerializersForValueType';
-import { DummyScene } from './Abstractions/Drivers/DummyScene';
 import { IScene } from './Abstractions/IScene';
 import { SetSceneProperty } from './Actions/SetSceneProperty';
 import { OnSceneNodeClick } from './Events/OnSceneNodeClick';
@@ -24,10 +23,14 @@ import { Vec3Value } from './Values/Vec3Value';
 import * as Vec4Nodes from './Values/Vec4Nodes';
 import { Vec4Value } from './Values/Vec4Value';
 
-export function registerSceneProfile(
-  registry: Registry,
-  scene: IScene = new DummyScene()
+export function registerSceneDependency(
+  dependencies: IRegistry['dependencies'],
+  scene: IScene
 ) {
+  dependencies.register('scene', scene);
+}
+
+export function registerSceneProfile(registry: Registry) {
   const { values, nodes } = registry;
 
   // pull in value type nodes
@@ -52,16 +55,12 @@ export function registerSceneProfile(
 
   // events
 
-  nodes.register(OnSceneNodeClick.Description);
+  nodes.register(OnSceneNodeClick);
 
   // actions
   const allValueTypeNames = values.getAllNames();
-  nodes.register(
-    ...SetSceneProperty.GetDescriptions(scene, ...allValueTypeNames)
-  );
-  nodes.register(
-    ...GetSceneProperty.GetDescriptions(scene, ...allValueTypeNames)
-  );
+  nodes.register(...SetSceneProperty(allValueTypeNames));
+  nodes.register(...GetSceneProperty(allValueTypeNames));
 
   const newValueTypeNames = [
     'vec2',

--- a/packages/core/src/Profiles/Scene/registerSceneProfile.ts
+++ b/packages/core/src/Profiles/Scene/registerSceneProfile.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { getNodeDescriptions } from '../../Nodes/Registry/NodeDescription';
-import { IRegistry, Registry } from '../../Registry';
+import { IRegistry } from '../../Registry';
 import { registerSerializersForValueType } from '../Core/registerSerializersForValueType';
 import { IScene } from './Abstractions/IScene';
 import { SetSceneProperty } from './Actions/SetSceneProperty';
@@ -30,7 +30,9 @@ export function registerSceneDependency(
   dependencies.register('scene', scene);
 }
 
-export function registerSceneProfile(registry: Registry) {
+export function registerSceneProfile(
+  registry: Pick<IRegistry, 'values' | 'nodes'>
+) {
   const { values, nodes } = registry;
 
   // pull in value type nodes

--- a/packages/core/src/Registry.ts
+++ b/packages/core/src/Registry.ts
@@ -1,7 +1,15 @@
+import { DependenciesRegistry } from './Nodes/Registry/DependenciesRegistry';
 import { NodeTypeRegistry } from './Nodes/Registry/NodeTypeRegistry';
 import { ValueTypeRegistry } from './Values/ValueTypeRegistry';
 
-export class Registry {
+export interface IRegistry {
+  readonly values: ValueTypeRegistry;
+  readonly nodes: NodeTypeRegistry;
+  readonly dependencies: DependenciesRegistry;
+}
+
+export class Registry implements IRegistry {
   public readonly values = new ValueTypeRegistry();
   public readonly nodes = new NodeTypeRegistry();
+  public readonly dependencies = new DependenciesRegistry();
 }

--- a/packages/flow/src/components/Controls.tsx
+++ b/packages/flow/src/components/Controls.tsx
@@ -4,6 +4,8 @@ import {
   ManualLifecycleEventEmitter,
   readGraphFromJSON,
   registerCoreProfile,
+  registerLifecycleEventEmitter,
+  registerLogger,
   registerSceneProfile,
   Registry,
 } from "@behave-graph/core";
@@ -36,8 +38,10 @@ const CustomControls = () => {
     const registry = new Registry();
     const logger = new DefaultLogger();
     const manualLifecycleEventEmitter = new ManualLifecycleEventEmitter();
-    registerCoreProfile(registry, logger, manualLifecycleEventEmitter);
+    registerCoreProfile(registry);
     registerSceneProfile(registry);
+    registerLogger(registry.dependencies, logger);
+    registerLifecycleEventEmitter(registry.dependencies, manualLifecycleEventEmitter)
     
     const nodes = instance.getNodes();
     const edges = instance.getEdges();

--- a/packages/flow/tsconfig.json
+++ b/packages/flow/tsconfig.json
@@ -5,5 +5,6 @@
     "declaration": false,
     "emitDeclarationOnly": false
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts"]
 }

--- a/packages/flow/tsconfig.json
+++ b/packages/flow/tsconfig.json
@@ -5,6 +5,5 @@
     "declaration": false,
     "emitDeclarationOnly": false
   },
-  "include": ["./src"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["./src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "outDir": "./dist"
   },
   "include": ["packages/core/src", "packages/flow/src"],
-  "exclude": ["**/*node_modules", "dist", "*.test.ts"],
+  "exclude": ["**/*node_modules", "dist", "**/*.test.ts"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "outDir": "./dist"
   },
   "include": ["packages/core/src", "packages/flow/src"],
-  "exclude": ["**/*node_modules", "dist", "**/*.test.ts"],
+  "exclude": ["**/*node_modules", "dist", "*.test.ts"],
 }


### PR DESCRIPTION
This follows a similar pattern before that was there with `AbstractionRegistry`.

Now - you no longer need to define dependencies when requested a node definition, you just need to register dependencies with the registry which can be grabbed later.

This was suggested by @aitorllj93 - and it makes the code around definitions much easier to work with and test as it requires less setup. 

Only downside is it is a bit more brittle, there is no guarantee anymore that the dependencies are provided when the node is executed.

Before you would need to know the abstractions when setting up the registry and before building the node definitions because some node definitions required it at initialization time.

Now you can create the node defintiions without needing the dependencies, and you can register the dependencies at a later time; the dependencies are only needed when executing/triggering nodes.