### PR TITLE
Registry type again, adding scene profile to exec-graph & export-node-spec & graph-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ Here is a test of 10,000,000 iteration for loop:
 
 [/graphs/core/flow/PerformanceTest.json](/graphs/core/flow/PerformanceTest.json)
 
-Here is the command running with profiling (-p):
+Here is the command running with verbose logging, e.g. "-l 0":
 
 ```sh
-npx exec-graph ./graphs/core/flow/PerformanceTest.json -p
+npx exec-graph ./graphs/core/flow/PerformanceTest.json -l 0
 ```
 
 Console output:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Another neat fact about behavior graphs is that they offer a sand boxed executio
 
 ## Documentation
 
-* [Extending the Value System](/docs/Values.md)
-* [Types Of Nodes](/docs/TypesOfNodes.md)
-* [Abstractions and Drivers](/docs/Abstractions.md)
+- [Extending the Value System](/docs/Values.md)
+- [Types Of Nodes](/docs/TypesOfNodes.md)
+- [Abstractions and Drivers](/docs/Abstractions.md)
 
 ## Community Resources
 
@@ -34,21 +34,21 @@ This library, while small, contains a nearly complete implementation of behavior
 
 ### Features
 
-* **Customizable** While this library contains a lot of nodes, you do not have to expose all of them. For example, just because this supports for-loops and state, does not mean you have to register that node type as being available.
-* **Type Safe** This library is implemented in TypeScript and fully makes use of its type safety features.
-* **Small** This is a very small library with no external dependencies.
-* **Simple** This library is implemented in a forward fashion without unnecessary complexity.
-* **High Performance** Currently in performance testing, the library achieves over 2M node executions per second.
+- **Customizable** While this library contains a lot of nodes, you do not have to expose all of them. For example, just because this supports for-loops and state, does not mean you have to register that node type as being available.
+- **Type Safe** This library is implemented in TypeScript and fully makes use of its type safety features.
+- **Small** This is a very small library with no external dependencies.
+- **Simple** This library is implemented in a forward fashion without unnecessary complexity.
+- **High Performance** Currently in performance testing, the library achieves over 2M node executions per second.
 
 ### Node Types
 
-* **Events** You can implement arbitrary events that start execution: Start, Tick
-* **Actions** You can implement actions that trigger animations, scene scene variations, or update internal state: Log
-* **Logic** You can do arithmetic, trigonometry as well as vector operations and string manipulation: Add, Subtract, Multiply, Divide, Pow, Exp, Log, Log2, Log10, Min, Max, Round, Ceil, Floor, Sign, Abs, Trunc, Sqrt, Negate, And, Or, Not, ==, >, >=, <, <=, isNan, isInfinity, concat, includes.
-* **Queries** You can query the state from the system.
-* **Flow Control** Control execution flow using familiar structures: Branch, Delay, Debounce, Throttle, FlipFlop, Sequence, Gate, MultiGate, DoOnce, DoN, ForLoop
-* **Variables** You can create, set and get variable values.
-* **Custom Events** You can create, listen to and trigger custom events.
+- **Events** You can implement arbitrary events that start execution: Start, Tick
+- **Actions** You can implement actions that trigger animations, scene scene variations, or update internal state: Log
+- **Logic** You can do arithmetic, trigonometry as well as vector operations and string manipulation: Add, Subtract, Multiply, Divide, Pow, Exp, Log, Log2, Log10, Min, Max, Round, Ceil, Floor, Sign, Abs, Trunc, Sqrt, Negate, And, Or, Not, ==, >, >=, <, <=, isNan, isInfinity, concat, includes.
+- **Queries** You can query the state from the system.
+- **Flow Control** Control execution flow using familiar structures: Branch, Delay, Debounce, Throttle, FlipFlop, Sequence, Gate, MultiGate, DoOnce, DoN, ForLoop
+- **Variables** You can create, set and get variable values.
+- **Custom Events** You can create, listen to and trigger custom events.
 
 ### Designed for Integration into Other Systems
 
@@ -75,7 +75,7 @@ The example behavior graphs are in the `/examples` folder. You can execute these
 The main syntax is this one:
 
 ```zsh
-npm run exec-graph ../../graphs/[examplename].json
+npx exec-graph ./graphs/[examplename].json
 ```
 
 Here are some example graphs in their native JSON form:
@@ -88,9 +88,13 @@ Print out the text "Hello World!" as soon as the graph starts up!
 
 Console output:
 
-```zsh
-npm run exec-graph ../../graphs/core/HelloWorld.json
+```sh
+npx exec-graph ./graphs/core/HelloWorld.json
+```
 
+Console output:
+
+```sh
 Hello World!
 ```
 
@@ -102,9 +106,13 @@ In this example, we use set a variable and also listen to when it changes.
 
 Console output:
 
-```zsh
-> npm run exec-graph ../../graphs/core/variables/Changed.json
+```sh
+npx exec-graph ./graphs/core/variables/Changed.json
+```
 
+Console output:
+
+```sh
 391
 ```
 
@@ -114,11 +122,15 @@ This example shows how to branching execution works. The "flow/branch" node has 
 
 [/graphs/core/flow/Branch.json](/graphs/core/flow/Branch.json)
 
+Command:
+
+```sh
+npx exec-graph ./graphs/core/flow/Branch.json
+```
+
 Console output:
 
-```zsh
-> npm run exec-graph ../../graphs/core/flow/Branch.json
-
+```sh
 Condition is false!
 ```
 
@@ -128,11 +140,15 @@ This shows how to create math formulas in logic nodes. In this case the equation
 
 [/graphs/core/logic/Polynomial.json](/graphs/core/logic/Polynomial.json)
 
+Command:
+
+```sh
+npx exec-graph ./graphs/core/logic/Polynomial.json
+```
+
 Console output:
 
-```zsh
-> npm run exec-graph ../../graphs/core/logic/Polynomial.json
-
+```sh
 -9
 ```
 
@@ -142,11 +158,15 @@ Behave-Graph support asynchronous nodes. These are nodes which will continue exe
 
 [/graphs/core/async/Delay.json](/graphs/core/async/Delay.json)
 
+Command:
+
+```sh
+npx exec-graph ./graphs/core/async/Delay.json
+```
+
 Console output:
 
-```zsh
-> npm run exec-graph ../../graphs/core/async/Delay.json
-
+```sh
 Waiting...
 One Second Later!
 ```
@@ -157,11 +177,15 @@ Building upon waiting for downstream nodes to execute, you can also execute For 
 
 [/graphs/core/flow/ForLoop.json](/graphs/core/flow/ForLoop.json)
 
+Command:
+
+```sh
+npx exec-graph ./graphs/core/flow/ForLoop.json
+```
+
 Console output:
 
-```zsh
-> npm run exec-graph ../../graphs/core/flow/ForLoop.json
-
+```sh
 Starting For Loop...
 Loop Body!
 Loop Body!
@@ -184,9 +208,13 @@ You can register custom events, trigger then and listen on them.
 
 Console output:
 
-```zsh
-> npm run exec-graph ../../graphs/core/events/CustomEvents.json
+```sh
+npx exec-graph ./graphs/core/events/CustomEvents.json
+```
 
+Console output:
+
+```sh
 myCustomEvent Fired!
 myCustomEvent Fired!
 myCustomEvent Fired!
@@ -200,11 +228,15 @@ Here is a test of 10,000,000 iteration for loop:
 
 [/graphs/core/flow/PerformanceTest.json](/graphs/core/flow/PerformanceTest.json)
 
-Here is the console output, when running with profiling (-p):
+Here is the command running with profiling (-p):
 
-```zsh
-> npm run exec-graph ../../graphs/core/flow/PerformanceTest.json -- -- -p
+```sh
+npx exec-graph ./graphs/core/flow/PerformanceTest.json -p
+```
 
+Console output:
+
+```sh
 Starting 10,000,000 iteration for-loop...
 1,000,000 more iterations...
 1,000,000 more iterations...
@@ -218,5 +250,5 @@ Starting 10,000,000 iteration for-loop...
 1,000,000 more iterations...
 Completed all iterations!
 
-    30000013 nodes executed in 2.98 seconds, at a rate of 10067118 steps/second
+  Profile Results: 30000014 nodes executed in 2.742 seconds, at a rate of 10940924 steps/second
 ```

--- a/apps/exec-graph/bin/cli.js
+++ b/apps/exec-graph/bin/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --enable-source-maps
 
 import { main } from '../dist/index.js';
 

--- a/apps/exec-graph/package.json
+++ b/apps/exec-graph/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@behave-graph/core": "*"
+    "@behave-graph/core": "*",
+    "@behave-graph/scene": "*"
   }
 }

--- a/apps/exec-graph/src/index.ts
+++ b/apps/exec-graph/src/index.ts
@@ -27,7 +27,6 @@ type ProgramOptions = {
   upgrade?: boolean;
   logLevel?: number;
   dryRun?: boolean;
-  profile?: boolean;
   iterations: string;
 };
 
@@ -105,7 +104,6 @@ async function execGraph({
 
     Logger.verbose('executing all (async)');
     await engine.executeAllAsync(5);
-    Logger.verbose('  completed');
   }
 
   if (lifecycleEventEmitter.tickEvent.listenerCount > 0) {
@@ -117,7 +115,6 @@ async function execGraph({
       Logger.verbose('executing all (async)');
       // eslint-disable-next-line no-await-in-loop
       await engine.executeAllAsync(5);
-      Logger.verbose('  completed');
     }
   }
 
@@ -127,19 +124,16 @@ async function execGraph({
 
     Logger.verbose('executing all (async)');
     await engine.executeAllAsync(5);
-    Logger.verbose('  completed');
   }
 
-  if (programOptions.profile) {
-    const deltaTime = Date.now() - startTime;
-    Logger.info(
-      `\n  Profile Results: ${engine.executionSteps} nodes executed in ${
-        deltaTime / 1000
-      } seconds, at a rate of ${Math.round(
-        (engine.executionSteps * 1000) / deltaTime
-      )} steps/second`
-    );
-  }
+  const deltaTime = Date.now() - startTime;
+  Logger.verbose(
+    `profile results: ${engine.executionSteps} nodes executed in ${
+      deltaTime / 1000
+    } seconds, at a rate of ${Math.round(
+      (engine.executionSteps * 1000) / deltaTime
+    )} steps/second`
+  );
 
   engine.dispose();
 }

--- a/apps/exec-graph/src/index.ts
+++ b/apps/exec-graph/src/index.ts
@@ -48,11 +48,7 @@ async function execGraph({
   const textFile = await fs.readFile(graphJsonPath);
   const graph = readGraphFromJSON({
     graphJson: JSON.parse(textFile.toString('utf8')),
-    ...registry,
-    dependencies: {
-      logger,
-      lifecycleEventEmitter
-    }
+    registry
   });
   graph.name = graphJsonPath;
 

--- a/apps/export-node-spec/bin/cli.js
+++ b/apps/export-node-spec/bin/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --enable-source-maps
 
 import { main } from '../dist/index.js';
 

--- a/apps/export-node-spec/package.json
+++ b/apps/export-node-spec/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {},
   "dependencies": {
     "@behave-graph/core": "*",
+    "@behave-graph/scene": "*",
     "csv-stringify": "^6.2.1"
   }
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,8 @@
 export default {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  'ts-jest': {
+    useESM: true
+  },
   resolver: 'ts-jest-resolver',
   testMatch: ['<rootDir>/packages/*/src/**/*.test.ts'],
   moduleNameMapper: { '^uuid$': 'uuid' } // see: https://stackoverflow.com/questions/73203367/jest-syntaxerror-unexpected-token-export-with-uuid-library

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@behave-graph/core": "*",
+        "@behave-graph/scene": "*",
         "csv-stringify": "^6.2.1"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,8 @@
     "apps/exec-graph": {
       "version": "0.0.1",
       "dependencies": {
-        "@behave-graph/core": "*"
+        "@behave-graph/core": "*",
+        "@behave-graph/scene": "*"
       },
       "bin": {
         "exec-graph": "bin/cli.js"

--- a/packages/core/src/Diagnostics/Logger.ts
+++ b/packages/core/src/Diagnostics/Logger.ts
@@ -29,7 +29,7 @@ export class Logger {
   public static readonly onError = new EventEmitter<string>();
 
   static {
-    const prefix = () => {
+    const prefix = (): string => {
       switch (Logger.prefixStyle) {
         case PrefixStyle.None:
           return '';

--- a/packages/core/src/Diagnostics/Logger.ts
+++ b/packages/core/src/Diagnostics/Logger.ts
@@ -2,7 +2,27 @@
 
 import { EventEmitter } from '../Events/EventEmitter.js';
 
+export enum LogLevel {
+  Verbose = 0,
+  Info = 1,
+  Warn = 2,
+  Error = 3
+}
+
+export enum PrefixStyle {
+  None = 0,
+  Time = 1
+}
+
+const Reset = '\x1b[0m';
+const FgRed = '\x1b[31m';
+const BgYellow = '\x1b[43m';
+const Dim = '\x1b[2m';
+
 export class Logger {
+  static logLevel = LogLevel.Info;
+  static prefixStyle = PrefixStyle.None;
+
   public static readonly onVerbose = new EventEmitter<string>();
   public static readonly onInfo = new EventEmitter<string>();
   public static readonly onWarn = new EventEmitter<string>();
@@ -10,19 +30,28 @@ export class Logger {
 
   static {
     const prefix = () => {
-      return new Date().toLocaleTimeString().padStart(11, '0');
+      switch (Logger.prefixStyle) {
+        case PrefixStyle.None:
+          return '';
+        case PrefixStyle.Time:
+          return new Date().toLocaleTimeString().padStart(11, '0') + ' ';
+      }
     };
+
     Logger.onVerbose.addListener((text: string) => {
-      console.log(prefix() + ` VERB:  ${text}`);
+      if (Logger.logLevel > LogLevel.Verbose) return;
+      console.log(prefix() + `${Dim}${text}${Reset}`);
     });
     Logger.onInfo.addListener((text: string) => {
-      console.log(prefix() + ` INFO:  ${text}`);
+      if (Logger.logLevel > LogLevel.Info) return;
+      console.log(prefix() + `${text}`);
     });
     Logger.onWarn.addListener((text: string) => {
-      console.warn(prefix() + ` WARN:  ${text}`);
+      if (Logger.logLevel > LogLevel.Warn) return;
+      console.warn(prefix() + `${BgYellow}${text}${Reset}`);
     });
     Logger.onError.addListener((text: string) => {
-      console.error(prefix() + ` ERR:  ${text}`);
+      console.error(prefix() + `${FgRed}${text}}${Reset}`);
     });
   }
 

--- a/packages/core/src/Graphs/Graph.ts
+++ b/packages/core/src/Graphs/Graph.ts
@@ -67,21 +67,25 @@ export const createNode = ({
 export const makeGraphApi = ({
   variables = {},
   customEvents = {},
-  valuesTypeRegistry,
+  values,
   dependencies = {}
 }: {
   customEvents?: GraphCustomEvents;
   variables?: GraphVariables;
-  valuesTypeRegistry: ValueTypeMap;
+  values: ValueTypeMap;
   dependencies: Dependencies;
 }): IGraphApi => ({
   variables,
   customEvents,
-  values: valuesTypeRegistry,
+  values,
   getDependency: (id: string) => {
     const result = dependencies[id];
     if (!result)
-      console.error(`Dependency not found ${id}.  Did you register it?`);
+      console.error(
+        `Dependency not found ${id}.  Did you register it? Existing dependencies: ${Object.keys(
+          dependencies
+        )}`
+      );
     return result;
   }
 });

--- a/packages/core/src/Graphs/Graph.ts
+++ b/packages/core/src/Graphs/Graph.ts
@@ -1,4 +1,5 @@
 import { CustomEvent } from '../Events/CustomEvent.js';
+import { Logger } from '../index.js';
 import { Metadata } from '../Metadata.js';
 import { NodeConfiguration } from '../Nodes/Node.js';
 import { Dependencies } from '../Nodes/NodeDefinitions.js';
@@ -46,6 +47,7 @@ export const createNode = ({
     nodeDefinition = registry.nodes[nodeTypeName];
   }
   if (nodeDefinition === undefined) {
+    Logger.verbose('known nodes: ' + Object.keys(registry.nodes).join(', '));
     throw new Error(
       `no registered node descriptions with the typeName ${nodeTypeName}`
     );

--- a/packages/core/src/Graphs/Graph.ts
+++ b/packages/core/src/Graphs/Graph.ts
@@ -3,7 +3,7 @@ import { Metadata } from '../Metadata.js';
 import { NodeConfiguration } from '../Nodes/Node.js';
 import { Dependencies } from '../Nodes/NodeDefinitions.js';
 import { INode } from '../Nodes/NodeInstance.js';
-import { NodeDefinitionsMap } from '../Nodes/Registry/NodeDefinitionsMap.js';
+import { IRegistry } from '../Registry.js';
 import { Socket } from '../Sockets/Socket.js';
 import { ValueTypeMap } from '../Values/ValueTypeMap.js';
 import { Variable } from '../Values/Variables/Variable.js';
@@ -32,20 +32,18 @@ export type GraphInstance = {
 
 export const createNode = ({
   graph,
-  nodes,
-  values,
+  registry,
   nodeTypeName,
   nodeConfiguration = {}
 }: {
   graph: IGraphApi;
-  nodes: NodeDefinitionsMap;
-  values: ValueTypeMap;
+  registry: IRegistry;
   nodeTypeName: string;
   nodeConfiguration?: NodeConfiguration;
 }) => {
   let nodeDefinition = undefined;
-  if (nodes[nodeTypeName]) {
-    nodeDefinition = nodes[nodeTypeName];
+  if (registry.nodes[nodeTypeName]) {
+    nodeDefinition = registry.nodes[nodeTypeName];
   }
   if (nodeDefinition === undefined) {
     throw new Error(
@@ -57,7 +55,7 @@ export const createNode = ({
 
   node.inputs.forEach((socket: Socket) => {
     if (socket.valueTypeName !== 'flow' && socket.value === undefined) {
-      socket.value = values[socket.valueTypeName]?.creator();
+      socket.value = registry.values[socket.valueTypeName]?.creator();
     }
   });
 

--- a/packages/core/src/Graphs/IO/readGraphFromJSON.test.ts
+++ b/packages/core/src/Graphs/IO/readGraphFromJSON.test.ts
@@ -1,10 +1,19 @@
 import { Logger } from '../../Diagnostics/Logger.js';
-import { getCoreRegistry } from '../../Profiles/Core/registerCoreProfile.js';
+import { ManualLifecycleEventEmitter } from '../../Profiles/Core/Abstractions/Drivers/ManualLifecycleEventEmitter.js';
+import { registerCoreProfile } from '../../Profiles/Core/registerCoreProfile.js';
 import { readGraphFromJSON } from './readGraphFromJSON.js';
 Logger.onWarn.clear();
 
 describe('readGraphFromJSON', () => {
-  const registry = getCoreRegistry();
+  const registry = registerCoreProfile({
+    values: {},
+    nodes: {},
+    dependencies: {
+      ILogger: new Logger(),
+      ILifecycleEventEmitter: new ManualLifecycleEventEmitter()
+    }
+  });
+
   it('throws if node ids are not unique', () => {
     const json = {
       variables: [],
@@ -20,9 +29,7 @@ describe('readGraphFromJSON', () => {
         }
       ]
     };
-    expect(() =>
-      readGraphFromJSON({ graphJson: json, ...registry, dependencies: {} })
-    ).toThrow();
+    expect(() => readGraphFromJSON({ graphJson: json, registry })).toThrow();
   });
 
   it("throws if input keys don't match known sockets", () => {
@@ -39,9 +46,7 @@ describe('readGraphFromJSON', () => {
         }
       ]
     };
-    expect(() =>
-      readGraphFromJSON({ graphJson: json, ...registry, dependencies: {} })
-    ).toThrow();
+    expect(() => readGraphFromJSON({ graphJson: json, registry })).toThrow();
   });
 
   it('throws if input points to non-existent node', () => {
@@ -65,9 +70,7 @@ describe('readGraphFromJSON', () => {
         }
       ]
     };
-    expect(() =>
-      readGraphFromJSON({ graphJson: json, ...registry, dependencies: {} })
-    ).toThrow();
+    expect(() => readGraphFromJSON({ graphJson: json, registry })).toThrow();
   });
 
   it('throws if input points to non-existent socket', () => {
@@ -91,8 +94,6 @@ describe('readGraphFromJSON', () => {
         }
       ]
     };
-    expect(() =>
-      readGraphFromJSON({ graphJson: json, ...registry, dependencies: {} })
-    ).toThrow();
+    expect(() => readGraphFromJSON({ graphJson: json, registry })).toThrow();
   });
 });

--- a/packages/core/src/Graphs/IO/readGraphFromJSON.ts
+++ b/packages/core/src/Graphs/IO/readGraphFromJSON.ts
@@ -3,7 +3,6 @@ import { CustomEvent } from '../../Events/CustomEvent.js';
 import { Link } from '../../Nodes/Link.js';
 import { NodeConfiguration } from '../../Nodes/Node.js';
 import { INode } from '../../Nodes/NodeInstance.js';
-import { NodeDefinitionsMap } from '../../Nodes/Registry/NodeDefinitionsMap.js';
 import { IRegistry } from '../../Registry.js';
 import { Socket } from '../../Sockets/Socket.js';
 import { ValueTypeMap } from '../../Values/ValueTypeMap.js';
@@ -69,8 +68,7 @@ export function readGraphFromJSON({
     const nodeJson = nodesJson[i];
     const node = readNodeJSON({
       graph: graphApi,
-      nodes: registry.nodes,
-      values: registry.values,
+      registry,
       nodeJson
     });
     const id = nodeJson.id;
@@ -166,13 +164,11 @@ export function readGraphFromJSON({
 
 function readNodeJSON({
   graph,
-  nodes,
-  values,
+  registry,
   nodeJson
 }: {
   graph: IGraphApi;
-  nodes: NodeDefinitionsMap;
-  values: ValueTypeMap;
+  registry: IRegistry;
   nodeJson: NodeJSON;
 }) {
   if (nodeJson.type === undefined) {
@@ -189,8 +185,7 @@ function readNodeJSON({
 
   const node = createNode({
     graph,
-    nodes,
-    values,
+    registry,
     nodeTypeName: nodeName,
     nodeConfiguration
   });
@@ -199,7 +194,7 @@ function readNodeJSON({
   node.metadata = nodeJson?.metadata ?? node.metadata;
 
   if (nodeJson.parameters !== undefined) {
-    readNodeParameterJSON(values, node, nodeJson.parameters);
+    readNodeParameterJSON(registry.values, node, nodeJson.parameters);
   }
   if (nodeJson.flows !== undefined) {
     readNodeFlowsJSON(node, nodeJson.flows);

--- a/packages/core/src/Graphs/IO/writeGraphToJSON.ts
+++ b/packages/core/src/Graphs/IO/writeGraphToJSON.ts
@@ -1,4 +1,4 @@
-import { ValueTypeMap } from '../../Values/ValueTypeMap.js';
+import { IRegistry } from '../../Registry.js';
 import { GraphInstance } from '../Graph.js';
 import {
   CustomEventJSON,
@@ -13,7 +13,7 @@ import {
 
 export function writeGraphToJSON(
   graph: GraphInstance,
-  valuesRegistry: ValueTypeMap
+  registry: IRegistry
 ): GraphJSON {
   const graphJson: GraphJSON = {};
 
@@ -56,7 +56,7 @@ export function writeGraphToJSON(
       valueTypeName: variable.valueTypeName,
       name: variable.name,
       id: variable.id,
-      initialValue: valuesRegistry[variable.valueTypeName]?.serialize(
+      initialValue: registry.values[variable.valueTypeName]?.serialize(
         variable.initialValue
       )
     };
@@ -100,7 +100,7 @@ export function writeGraphToJSON(
 
       if (inputSocket.links.length === 0) {
         parameterJson = {
-          value: valuesRegistry[inputSocket.valueTypeName]?.serialize(
+          value: registry.values[inputSocket.valueTypeName]?.serialize(
             inputSocket.value
           )
         };

--- a/packages/core/src/Graphs/IO/writeNodeSpecsToJSON.ts
+++ b/packages/core/src/Graphs/IO/writeNodeSpecsToJSON.ts
@@ -1,7 +1,7 @@
 import { NodeCategory } from '../../Nodes/NodeDefinitions.js';
 import { IRegistry } from '../../Registry.js';
 import { Choices } from '../../Sockets/Socket.js';
-import { createNode, IGraphApi } from '../Graph.js';
+import { createNode, makeGraphApi } from '../Graph.js';
 import {
   ChoiceJSON,
   InputSocketSpecJSON,
@@ -25,12 +25,12 @@ export function writeNodeSpecsToJSON({
 
   // const graph = new Graph(registry);
 
-  const graph: IGraphApi = {
-    values: values,
+  const graph = makeGraphApi({
+    values,
     customEvents: {},
-    getDependency: <T>(id: string) => dependencies[id] as T,
+    dependencies,
     variables: {}
-  };
+  });
 
   Object.keys(nodes).forEach((nodeTypeName) => {
     const node = createNode({

--- a/packages/core/src/Graphs/IO/writeNodeSpecsToJSON.ts
+++ b/packages/core/src/Graphs/IO/writeNodeSpecsToJSON.ts
@@ -16,27 +16,21 @@ function toChoices(valueChoices: Choices | undefined): ChoiceJSON | undefined {
   });
 }
 
-export function writeNodeSpecsToJSON({
-  values,
-  nodes,
-  dependencies
-}: IRegistry): NodeSpecJSON[] {
+export function writeNodeSpecsToJSON(registry: IRegistry): NodeSpecJSON[] {
   const nodeSpecsJSON: NodeSpecJSON[] = [];
 
   // const graph = new Graph(registry);
 
   const graph = makeGraphApi({
-    values,
+    ...registry,
     customEvents: {},
-    dependencies,
     variables: {}
   });
 
-  Object.keys(nodes).forEach((nodeTypeName) => {
+  Object.keys(registry.nodes).forEach((nodeTypeName) => {
     const node = createNode({
       graph,
-      nodes,
-      values,
+      registry,
       nodeTypeName
     });
 
@@ -53,7 +47,7 @@ export function writeNodeSpecsToJSON({
       const valueType =
         inputSocket.valueTypeName === 'flow'
           ? undefined
-          : values[inputSocket.valueTypeName];
+          : registry.values[inputSocket.valueTypeName];
 
       let defaultValue = inputSocket.value;
       if (valueType !== undefined) {

--- a/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
+++ b/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
@@ -1,22 +1,19 @@
 import { createNode, makeGraphApi } from '../../Graphs/Graph.js';
-import { ValueTypeMap } from '../../Values/ValueTypeMap.js';
-import { NodeDefinitionsMap } from '../Registry/NodeDefinitionsMap.js';
+import { IRegistry } from '../../Registry.js';
 
 const nodeTypeNameRegex = /^\w+(\/\w+)*$/;
 const socketNameRegex = /^\w+$/;
 
 export function validateNodeRegistry({
   nodes,
-  values
-}: {
-  nodes: NodeDefinitionsMap;
-  values: ValueTypeMap;
-}): string[] {
+  values,
+  dependencies
+}: IRegistry): string[] {
   const errorList: string[] = [];
   // const graph = new Graph(registry);
   const graph = makeGraphApi({
-    valuesTypeRegistry: values,
-    dependencies: {}
+    values,
+    dependencies
   });
   Object.keys(nodes).forEach((nodeTypeName) => {
     const node = createNode({ graph, nodes, values, nodeTypeName });

--- a/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
+++ b/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
@@ -4,11 +4,7 @@ import { IRegistry } from '../../Registry.js';
 const nodeTypeNameRegex = /^\w+(\/\w+)*$/;
 const socketNameRegex = /^\w+$/;
 
-export function validateNodeRegistry({
-  registry
-}: {
-  registry: IRegistry;
-}): string[] {
+export function validateNodeRegistry(registry: IRegistry): string[] {
   const errorList: string[] = [];
   // const graph = new Graph(registry);
   const graph = makeGraphApi({

--- a/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
+++ b/packages/core/src/Nodes/Validation/validateNodeRegistry.ts
@@ -5,18 +5,17 @@ const nodeTypeNameRegex = /^\w+(\/\w+)*$/;
 const socketNameRegex = /^\w+$/;
 
 export function validateNodeRegistry({
-  nodes,
-  values,
-  dependencies
-}: IRegistry): string[] {
+  registry
+}: {
+  registry: IRegistry;
+}): string[] {
   const errorList: string[] = [];
   // const graph = new Graph(registry);
   const graph = makeGraphApi({
-    values,
-    dependencies
+    ...registry
   });
-  Object.keys(nodes).forEach((nodeTypeName) => {
-    const node = createNode({ graph, nodes, values, nodeTypeName });
+  Object.keys(registry.nodes).forEach((nodeTypeName) => {
+    const node = createNode({ graph, registry, nodeTypeName });
 
     // ensure node is registered correctly.
     if (node.description.typeName !== nodeTypeName) {
@@ -43,7 +42,7 @@ export function validateNodeRegistry({
       if (socket.valueTypeName === 'flow') {
         return;
       }
-      const valueType = values[socket.valueTypeName];
+      const valueType = registry.values[socket.valueTypeName];
       // check to ensure all value types are supported.
       if (valueType === undefined) {
         errorList.push(
@@ -61,7 +60,7 @@ export function validateNodeRegistry({
       if (socket.valueTypeName === 'flow') {
         return;
       }
-      const valueType = values[socket.valueTypeName];
+      const valueType = registry.values[socket.valueTypeName];
       // check to ensure all value types are supported.
       if (valueType === undefined) {
         errorList.push(

--- a/packages/core/src/Nodes/testUtils.ts
+++ b/packages/core/src/Nodes/testUtils.ts
@@ -12,7 +12,7 @@ import { NodeConfigurationDescription } from './Registry/NodeDescription.js';
 const makeEmptyGraph = (): IGraphApi => {
   return makeGraphApi({
     dependencies: {},
-    valuesTypeRegistry: {}
+    values: {}
   });
 };
 

--- a/packages/core/src/Profiles/Core/Debug/DebugLog.ts
+++ b/packages/core/src/Profiles/Core/Debug/DebugLog.ts
@@ -4,8 +4,6 @@ import {
 } from '../../../Nodes/NodeDefinitions.js';
 import { ILogger } from '../Abstractions/ILogger.js';
 
-export const loggerDependencyKey = 'logger';
-
 export const Log = makeFlowNodeDefinition({
   typeName: 'debug/log',
   category: NodeCategory.Action,
@@ -23,7 +21,7 @@ export const Log = makeFlowNodeDefinition({
   out: { flow: 'flow' },
   initialState: undefined,
   triggered: ({ read, commit, graph: { getDependency } }) => {
-    const logger = getDependency<ILogger>(loggerDependencyKey);
+    const logger = getDependency<ILogger>('ILogger');
 
     const text = read<string>('text');
     switch (read<string>('severity')) {

--- a/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnEnd.ts
+++ b/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnEnd.ts
@@ -4,7 +4,6 @@ import {
   NodeCategory
 } from '../../../Nodes/NodeDefinitions.js';
 import { ILifecycleEventEmitter } from '../Abstractions/ILifecycleEventEmitter.js';
-import { lifecycleEventEmitterDependencyKey } from './LifecycleOnStart.js';
 
 // inspired by: https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/Blueprints/UserGuide/Events/
 
@@ -32,7 +31,7 @@ export const LifecycleOnEnd = makeEventNodeDefinition({
     };
 
     const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
-      lifecycleEventEmitterDependencyKey
+      'ILifecycleEventEmitter'
     );
 
     lifecycleEventEmitter?.endEvent.addListener(onEndEvent);
@@ -45,7 +44,7 @@ export const LifecycleOnEnd = makeEventNodeDefinition({
     Assert.mustBeTrue(onEndEvent !== undefined);
 
     const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
-      lifecycleEventEmitterDependencyKey
+      'ILifecycleEventEmitter'
     );
 
     if (onEndEvent) lifecycleEventEmitter?.endEvent.removeListener(onEndEvent);

--- a/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnStart.ts
+++ b/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnStart.ts
@@ -13,8 +13,6 @@ const makeInitialState = (): State => ({
   onStartEvent: undefined
 });
 
-export const lifecycleEventEmitterDependencyKey = 'lifecycleEventEmitter';
-
 export const LifecycleOnStart = makeEventNodeDefinition({
   typeName: 'lifecycle/onStart',
   label: 'On Start',
@@ -31,7 +29,7 @@ export const LifecycleOnStart = makeEventNodeDefinition({
     };
 
     const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
-      lifecycleEventEmitterDependencyKey
+      'ILifecycleEventEmitter'
     );
 
     lifecycleEventEmitter?.startEvent.addListener(onStartEvent);
@@ -44,7 +42,7 @@ export const LifecycleOnStart = makeEventNodeDefinition({
     Assert.mustBeTrue(onStartEvent !== undefined);
 
     const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
-      lifecycleEventEmitterDependencyKey
+      'ILifecycleEventEmitter'
     );
 
     if (onStartEvent)

--- a/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnTick.ts
+++ b/packages/core/src/Profiles/Core/Lifecycle/LifecycleOnTick.ts
@@ -4,7 +4,6 @@ import {
   NodeCategory
 } from '../../../Nodes/NodeDefinitions.js';
 import { ILifecycleEventEmitter } from '../Abstractions/ILifecycleEventEmitter.js';
-import { lifecycleEventEmitterDependencyKey } from './LifecycleOnStart.js';
 
 type State = {
   onTickEvent?: (() => void) | undefined;
@@ -36,7 +35,7 @@ export const LifecycleOnTick = makeEventNodeDefinition({
     };
 
     const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
-      lifecycleEventEmitterDependencyKey
+      'ILifecycleEventEmitter'
     );
 
     lifecycleEventEmitter?.tickEvent.addListener(onTickEvent);
@@ -49,7 +48,7 @@ export const LifecycleOnTick = makeEventNodeDefinition({
     Assert.mustBeTrue(onTickEvent !== undefined);
 
     const lifecycleEventEmitter = getDependency<ILifecycleEventEmitter>(
-      lifecycleEventEmitterDependencyKey
+      'ILifecycleEventEmitter'
     );
 
     if (onTickEvent)

--- a/packages/core/src/Profiles/Core/registerCoreProfile.test.ts
+++ b/packages/core/src/Profiles/Core/registerCoreProfile.test.ts
@@ -1,9 +1,13 @@
 import { validateNodeRegistry } from '../../Nodes/Validation/validateNodeRegistry.js';
 import { validateValueRegistry } from '../../Values/Validation/validateValueRegistry.js';
-import { getCoreRegistry } from './registerCoreProfile.js';
+import { registerCoreProfile } from './registerCoreProfile.js';
 
 describe('core profile', () => {
-  const registry = getCoreRegistry();
+  const registry = registerCoreProfile({
+    values: {},
+    nodes: {},
+    dependencies: {}
+  });
 
   test('validate node registry', () => {
     expect(validateNodeRegistry(registry)).toHaveLength(0);

--- a/packages/core/src/Profiles/Core/registerCoreProfile.ts
+++ b/packages/core/src/Profiles/Core/registerCoreProfile.ts
@@ -5,12 +5,10 @@ import { getNodeDescriptions } from '../../Nodes/Registry/NodeDescription.js';
 import { IRegistry } from '../../Registry.js';
 import { ValueTypeMap } from '../../Values/ValueTypeMap.js';
 import { getStringConversionsForValueType } from '../registerSerializersForValueType.js';
-import { ILifecycleEventEmitter } from './Abstractions/ILifecycleEventEmitter.js';
-import { ILogger } from './Abstractions/ILogger.js';
 import { OnCustomEvent } from './CustomEvents/OnCustomEvent.js';
 import { TriggerCustomEvent } from './CustomEvents/TriggerCustomEvent.js';
 import { ExpectTrue as AssertExpectTrue } from './Debug/AssertExpectTrue.js';
-import { Log as DebugLog, loggerDependencyKey } from './Debug/DebugLog.js';
+import { Log as DebugLog } from './Debug/DebugLog.js';
 import { Branch } from './Flow/Branch.js';
 import { Counter } from './Flow/Counter.js';
 import { Debounce } from './Flow/Debounce.js';
@@ -26,10 +24,7 @@ import { SwitchOnString } from './Flow/SwitchOnString.js';
 import { Throttle } from './Flow/Throttle.js';
 import { WaitAll } from './Flow/WaitAll.js';
 import { LifecycleOnEnd } from './Lifecycle/LifecycleOnEnd.js';
-import {
-  lifecycleEventEmitterDependencyKey,
-  LifecycleOnStart
-} from './Lifecycle/LifecycleOnStart.js';
+import { LifecycleOnStart } from './Lifecycle/LifecycleOnStart.js';
 import { LifecycleOnTick } from './Lifecycle/LifecycleOnTick.js';
 import { Easing } from './Logic/Easing.js';
 import { Delay } from './Time/Delay.js';
@@ -44,17 +39,6 @@ import * as StringNodes from './Values/StringNodes.js';
 import { StringValue } from './Values/StringValue.js';
 import { VariableGet } from './Variables/VariableGet.js';
 import { VariableSet } from './Variables/VariableSet.js';
-
-export const makeCoreDependencies = ({
-  lifecycleEmitter,
-  logger
-}: {
-  lifecycleEmitter: ILifecycleEventEmitter;
-  logger: ILogger;
-}) => ({
-  [lifecycleEventEmitterDependencyKey]: lifecycleEmitter,
-  [loggerDependencyKey]: logger
-});
 
 export const getCoreValuesMap = memo<ValueTypeMap>(() => {
   const valueTypes = [BooleanValue, StringValue, IntegerValue, FloatValue];

--- a/packages/core/src/memo.ts
+++ b/packages/core/src/memo.ts
@@ -7,3 +7,13 @@ export function memo<T>(func: () => T): () => T {
     return cache;
   };
 }
+
+export function asyncMemo<T>(func: () => Promise<T>): () => Promise<T> {
+  let cache: T | undefined;
+  return async (): Promise<T> => {
+    if (cache === undefined) {
+      cache = await func();
+    }
+    return cache;
+  };
+}

--- a/packages/core/src/validateRegistry.ts
+++ b/packages/core/src/validateRegistry.ts
@@ -6,7 +6,7 @@ export function validateRegistry(registry: IRegistry): string[] {
   const errorList: string[] = [];
   errorList.push(
     ...validateValueRegistry(registry.values),
-    ...validateNodeRegistry({ registry })
+    ...validateNodeRegistry(registry)
   );
   return errorList;
 }

--- a/packages/core/src/validateRegistry.ts
+++ b/packages/core/src/validateRegistry.ts
@@ -1,19 +1,16 @@
-import { NodeDefinitionsMap } from './Nodes/Registry/NodeDefinitionsMap.js';
 import { validateNodeRegistry } from './Nodes/Validation/validateNodeRegistry.js';
+import { IRegistry } from './Registry.js';
 import { validateValueRegistry } from './Values/Validation/validateValueRegistry.js';
-import { ValueTypeMap } from './Values/ValueTypeMap.js';
 
 export function validateRegistry({
   nodes,
-  values
-}: {
-  nodes: NodeDefinitionsMap;
-  values: ValueTypeMap;
-}): string[] {
+  values,
+  dependencies
+}: IRegistry): string[] {
   const errorList: string[] = [];
   errorList.push(
     ...validateValueRegistry(values),
-    ...validateNodeRegistry({ nodes, values })
+    ...validateNodeRegistry({ nodes, values, dependencies })
   );
   return errorList;
 }

--- a/packages/core/src/validateRegistry.ts
+++ b/packages/core/src/validateRegistry.ts
@@ -2,15 +2,11 @@ import { validateNodeRegistry } from './Nodes/Validation/validateNodeRegistry.js
 import { IRegistry } from './Registry.js';
 import { validateValueRegistry } from './Values/Validation/validateValueRegistry.js';
 
-export function validateRegistry({
-  nodes,
-  values,
-  dependencies
-}: IRegistry): string[] {
+export function validateRegistry(registry: IRegistry): string[] {
   const errorList: string[] = [];
   errorList.push(
-    ...validateValueRegistry(values),
-    ...validateNodeRegistry({ nodes, values, dependencies })
+    ...validateValueRegistry(registry.values),
+    ...validateNodeRegistry({ registry })
   );
   return errorList;
 }

--- a/packages/flow/src/components/Flow.tsx
+++ b/packages/flow/src/components/Flow.tsx
@@ -20,17 +20,9 @@ export const Flow: React.FC<FlowProps> = ({
   initialGraph: graph,
   examples
 }) => {
-  const {
-    nodeDefinitions,
-    valuesDefinitions,
-    dependencies: dependencies
-  } = useCoreRegistry();
+  const registry = useCoreRegistry();
 
-  const specJson = useNodeSpecJson({
-    nodes: nodeDefinitions,
-    values: valuesDefinitions,
-    dependencies
-  });
+  const specJson = useNodeSpecJson(registry);
 
   const {
     nodes,
@@ -65,10 +57,7 @@ export const Flow: React.FC<FlowProps> = ({
 
   const { togglePlay, playing } = useGraphRunner({
     graphJson,
-    valueTypeDefinitions: valuesDefinitions,
-    nodeDefinitions,
-    eventEmitter: dependencies.lifecycleEventEmitter,
-    dependencies
+    registry
   });
 
   return (

--- a/packages/flow/src/hooks/useCoreRegistry.ts
+++ b/packages/flow/src/hooks/useCoreRegistry.ts
@@ -1,13 +1,17 @@
-import { getCoreNodesMap, getCoreValuesMap } from '@behave-graph/core';
+import {
+  getCoreNodesMap,
+  getCoreValuesMap,
+  IRegistry
+} from '@behave-graph/core';
 
 import { useCoreDependencies } from './useDependencies.js';
 
-export const useCoreRegistry = () => {
+export const useCoreRegistry = (): IRegistry => {
   const dependencies = useCoreDependencies();
 
   return {
-    nodeDefinitions: getCoreNodesMap(),
-    valuesDefinitions: getCoreValuesMap(),
+    nodes: getCoreNodesMap(),
+    values: getCoreValuesMap(),
     dependencies
   };
 };

--- a/packages/flow/src/hooks/useDependencies.ts
+++ b/packages/flow/src/hooks/useDependencies.ts
@@ -1,18 +1,17 @@
 import {
   DefaultLogger,
   Dependencies,
-  makeCoreDependencies,
   ManualLifecycleEventEmitter
 } from '@behave-graph/core';
 import { useEffect, useState } from 'react';
 
 export const useCoreDependencies = () => {
-  const [dependencies] = useState(() =>
-    makeCoreDependencies({
-      lifecycleEmitter: new ManualLifecycleEventEmitter(),
-      logger: new DefaultLogger()
-    })
-  );
+  const [dependencies] = useState(() => {
+    return {
+      ILifecycleEventEmitter: new ManualLifecycleEventEmitter(),
+      ILogger: new DefaultLogger()
+    };
+  });
 
   return dependencies;
 };

--- a/packages/flow/src/hooks/useNodeSpecJson.ts
+++ b/packages/flow/src/hooks/useNodeSpecJson.ts
@@ -1,30 +1,20 @@
 import {
-  Dependencies,
-  NodeDefinitionsMap,
+  IRegistry,
   NodeSpecJSON,
-  ValueTypeMap,
   writeNodeSpecsToJSON
 } from '@behave-graph/core';
 import { useEffect, useState } from 'react';
 
-export const useNodeSpecJson = ({
-  values,
-  nodes,
-  dependencies
-}: {
-  values: ValueTypeMap;
-  nodes: NodeDefinitionsMap;
-  dependencies: Dependencies | undefined;
-}) => {
+export const useNodeSpecJson = (registry: IRegistry) => {
   const [specJson, setSpecJson] = useState<NodeSpecJSON[]>();
 
   useEffect(() => {
-    if (!nodes || !values || !dependencies) {
+    if (!registry.nodes || !registry.values || !registry.dependencies) {
       setSpecJson(undefined);
       return;
     }
-    setSpecJson(writeNodeSpecsToJSON({ nodes, values, dependencies }));
-  }, [nodes, values, dependencies]);
+    setSpecJson(writeNodeSpecsToJSON(registry));
+  }, [registry.nodes, registry.values, registry.dependencies]);
 
   return specJson;
 };

--- a/packages/flow/src/transformers/flowToBehave.test.ts
+++ b/packages/flow/src/transformers/flowToBehave.test.ts
@@ -13,12 +13,8 @@ const flowGraph = rawFlowGraph as GraphJSON;
 const [nodes, edges] = behaveToFlow(flowGraph);
 
 it('transforms from flow to behave', () => {
-  const { values: valueTypes, nodes: nodeDefinitions } = getCoreRegistry();
-  const specJSON = writeNodeSpecsToJSON({
-    values: valueTypes,
-    nodes: nodeDefinitions,
-    dependencies: {}
-  });
+  const registry = getCoreRegistry();
+  const specJSON = writeNodeSpecsToJSON(registry);
   const output = flowToBehave(nodes, edges, specJSON);
   expect(output).toEqual(flowGraph);
 });

--- a/packages/scene/src/Nodes/Actions/SetSceneProperty.ts
+++ b/packages/scene/src/Nodes/Actions/SetSceneProperty.ts
@@ -1,6 +1,6 @@
 import { makeFlowNodeDefinition, NodeCategory } from '@behave-graph/core';
 
-import { getSceneDependency } from '../../dependencies.js';
+import { IScene } from '../../Abstractions/IScene.js';
 
 export const SetSceneProperty = (valueTypeNames: string[]) =>
   valueTypeNames.map((valueTypeName) =>
@@ -10,8 +10,7 @@ export const SetSceneProperty = (valueTypeNames: string[]) =>
       label: `Set Scene ${valueTypeName}`,
       in: {
         jsonPath: (_, graphApi) => {
-          const scene = getSceneDependency(graphApi.getDependency);
-
+          const scene = graphApi.getDependency<IScene>('IScene');
           return {
             valueType: 'string',
             choices: scene?.getProperties()
@@ -24,8 +23,8 @@ export const SetSceneProperty = (valueTypeNames: string[]) =>
         flow: 'flow'
       },
       initialState: undefined,
-      triggered: ({ commit, read, graph: { getDependency } }) => {
-        const scene = getSceneDependency(getDependency);
+      triggered: ({ commit, read, graph }) => {
+        const scene = graph.getDependency<IScene>('IScene');
         scene?.setProperty(read('jsonPath'), valueTypeName, read('value'));
         commit('flow');
       }

--- a/packages/scene/src/Nodes/Events/OnSceneNodeClick.ts
+++ b/packages/scene/src/Nodes/Events/OnSceneNodeClick.ts
@@ -5,7 +5,6 @@ import {
 } from '@behave-graph/core';
 
 import { IScene } from '../../Abstractions/IScene.js';
-import { getSceneDependency } from '../../dependencies.js';
 
 type State = {
   jsonPath?: string | undefined;
@@ -21,7 +20,7 @@ export const OnSceneNodeClick = makeEventNodeDefinition({
   label: 'On Scene Node Click',
   in: {
     jsonPath: (_, graphApi) => {
-      const scene = getSceneDependency(graphApi.getDependency);
+      const scene = graphApi.getDependency<IScene>('IScene');
 
       return {
         valueType: 'string',
@@ -33,14 +32,14 @@ export const OnSceneNodeClick = makeEventNodeDefinition({
     flow: 'flow'
   },
   initialState: initialState(),
-  init: ({ read, commit, graph: { getDependency } }) => {
+  init: ({ read, commit, graph }) => {
     const handleNodeClick = () => {
       commit('flow');
     };
 
     const jsonPath = read<string>('jsonPath');
 
-    const scene = getSceneDependency(getDependency);
+    const scene = graph.getDependency<IScene>('IScene');
     scene?.addOnClickedListener(jsonPath, handleNodeClick);
 
     const state: State = {

--- a/packages/scene/src/Nodes/Queries/GetSceneProperty.ts
+++ b/packages/scene/src/Nodes/Queries/GetSceneProperty.ts
@@ -1,6 +1,6 @@
 import { makeFunctionNodeDefinition, NodeCategory } from '@behave-graph/core';
 
-import { getSceneDependency } from '../../dependencies.js';
+import { IScene } from '../../Abstractions/IScene.js';
 
 export const GetSceneProperty = (valueTypeNames: string[]) =>
   valueTypeNames.map((valueTypeName) =>
@@ -10,20 +10,20 @@ export const GetSceneProperty = (valueTypeNames: string[]) =>
       label: `Scene set ${valueTypeName}`,
       in: {
         jsonPath: (_, graphApi) => {
-          const scene = getSceneDependency(graphApi.getDependency);
+          const scene = graphApi.getDependency<IScene>('IScene');
 
           return {
             valueType: 'string',
-            choices: scene.getProperties()
+            choices: scene?.getProperties()
           };
         }
       },
       out: {
         value: valueTypeName
       },
-      exec: ({ graph: { getDependency }, read, write }) => {
-        const scene = getSceneDependency(getDependency);
-        const propertyValue = scene.getProperty(
+      exec: ({ graph, read, write }) => {
+        const scene = graph.getDependency<IScene>('IScene');
+        const propertyValue = scene?.getProperty(
           read('jsonPath'),
           valueTypeName
         );

--- a/packages/scene/src/dependencies.ts
+++ b/packages/scene/src/dependencies.ts
@@ -1,9 +1,0 @@
-import { IGraphApi } from '@behave-graph/core';
-
-import { IScene } from './Abstractions/IScene.js';
-
-export const sceneDependencyKey = 'scene';
-
-export const getSceneDependency = (
-  getDependency: IGraphApi['getDependency']
-): IScene => getDependency<IScene>(sceneDependencyKey) as IScene;

--- a/packages/scene/src/registerSceneProfile.ts
+++ b/packages/scene/src/registerSceneProfile.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-len */
 import {
-  Dependencies,
   getCoreValuesMap,
   getNodeDescriptions,
   getStringConversionsForValueType,
@@ -11,8 +10,6 @@ import {
   ValueTypeMap
 } from '@behave-graph/core';
 
-import { IScene } from './Abstractions/IScene.js';
-import { sceneDependencyKey } from './dependencies.js';
 import { SetSceneProperty } from './Nodes/Actions/SetSceneProperty.js';
 import { OnSceneNodeClick } from './Nodes/Events/OnSceneNodeClick.js';
 import * as ColorNodes from './Nodes/Logic/ColorNodes.js';
@@ -32,10 +29,6 @@ import { QuatValue } from './Values/QuatValue.js';
 import { Vec2Value } from './Values/Vec2Value.js';
 import { Vec3Value } from './Values/Vec3Value.js';
 import { Vec4Value } from './Values/Vec4Value.js';
-
-export const createSceneDependency = (scene: IScene): Dependencies => ({
-  [sceneDependencyKey]: scene
-});
 
 export const getSceneValuesMap = memo<ValueTypeMap>(() => {
   const valueTypes = [
@@ -91,10 +84,6 @@ export const getSceneNodesMap = memo<Record<string, NodeDefinition>>(() => {
       nodeDefinition
     ])
   );
-});
-
-export const makeSceneDependencies = ({ scene }: { scene: IScene }) => ({
-  [sceneDependencyKey]: scene
 });
 
 export const registerSceneProfile = (registry: IRegistry): IRegistry => {

--- a/packages/scene/src/registerSceneProfile.ts
+++ b/packages/scene/src/registerSceneProfile.ts
@@ -41,15 +41,16 @@ export const getSceneValuesMap = memo<ValueTypeMap>(() => {
     Mat3Value,
     Mat4Value
   ];
-  return Object.fromEntries(
+  const temp = Object.fromEntries(
     valueTypes.map((valueType) => [valueType.name, valueType])
   );
+  return temp;
 });
 
 export const getSceneStringConversions = (
   values: Record<string, ValueType>
 ): NodeDefinition[] =>
-  Object.keys(getCoreValuesMap()).flatMap((valueTypeName) =>
+  Object.keys(values).flatMap((valueTypeName) =>
     getStringConversionsForValueType({ values, valueTypeName })
   );
 
@@ -58,6 +59,7 @@ export const getSceneNodesMap = memo<Record<string, NodeDefinition>>(() => {
     ...getCoreValuesMap(),
     ...getSceneValuesMap()
   });
+
   const nodeDefinitions = [
     // pull in value type nodes
     ...getNodeDescriptions(Vec2Nodes),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "paths": {
       "@behave-graph/core": ["./packages/core/"],
-      "@behave-graph/flow": ["./packages/flow/"]
+      "@behave-graph/flow": ["./packages/flow/"],
+      "@behave-graph/scene": ["./packages/scene/"]
     },
     "outDir": "dist",
     "target": "ES2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "compilerOptions": {
-    "paths": {
-      "@behave-graph/core": ["./packages/core/"],
-      "@behave-graph/flow": ["./packages/flow/"],
-      "@behave-graph/scene": ["./packages/scene/"]
-    },
     "outDir": "dist",
     "target": "ES2020",
     "module": "ES2020",
@@ -18,6 +13,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "allowJs": true
+    "allowJs": true,
+    "incremental": true
   }
 }


### PR DESCRIPTION
Restoring registry type, rather than always using destructured parameters. - DONE

Ensuring that exec-graph can use scene profile. - DONE

Ensure that export-node-spec supports scene profile. - DONE

Ensure that graph-editor supports scene profile. - DONE